### PR TITLE
feat: add leg4 — Postgres via JS bridge vs direct connection

### DIFF
--- a/experiments/001_hello_world/README.md
+++ b/experiments/001_hello_world/README.md
@@ -5,7 +5,11 @@ Validates the core claim from
 that WASM runtimes can replace Docker containers for serverless-style workloads with lower cold
 starts, smaller artifacts, and reduced memory.
 
-All three legs implement the same handler:
+Legs 1–3 implement the same handler. Legs 4a/4b extend the experiment with
+database access to measure whether the WASM host bridge pattern adds meaningful
+latency compared to a traditional direct database connection.
+
+All three Hello World legs implement the same handler:
 
 ```python
 def handle(request):
@@ -22,6 +26,8 @@ def handle(request):
 | H2 | **Cold start**: Podman slowest (~500ms+); Wasmtime fastest (<50ms); Pyodide/Chromium in between (~2–5s due to Chromium launch + Pyodide WASM init) | — |
 | H3 | **Memory**: Chromium process heaviest (300MB+); Flask/Podman moderate (~50MB); Wasmtime lightest (<10MB) | — |
 | H4 | **Warm p50**: All three comparable once runtime is loaded; Wasmtime expected fastest raw handler | — |
+| H5 | **Bridge overhead vs direct**: Negligible — dominated by actual query execution time | — |
+| H6 | **Connection pool location**: Host-side pool is equivalent to in-process pool | — |
 
 *Status column: fill with **confirmed** / **refuted** / **partially confirmed** after running `benchmark.sh`.*
 
@@ -38,7 +44,9 @@ def handle(request):
 
 ## Results
 
-*Run `./benchmark.sh` to populate this table.*
+*Run `./benchmark.sh` to populate these tables.*
+
+### Hello World (legs 1–3)
 
 | Metric | Leg 1 Flask/Podman | Leg 2 Pyodide/Chrome | Leg 3 Wasmtime |
 |---|---|---|---|
@@ -49,6 +57,17 @@ def handle(request):
 | hey p99 (ms) | | | |
 | hey req/s | | | |
 
+### Postgres DB query (legs 4a/4b)
+
+| Metric | Leg 4a Flask+psycopg2 | Leg 4b Pyodide+pg bridge |
+|---|---|---|
+| Artifact size | | |
+| Cold start (ms) | | |
+| Memory RSS (MB) | | |
+| hey p50 (ms) | | |
+| hey p99 (ms) | | |
+| hey req/s | | |
+
 ---
 
 ## Legs
@@ -58,6 +77,8 @@ def handle(request):
 | 1 | Flask in Podman/Docker container | 5001 | `leg1_flask_docker/run.sh` |
 | 2 | Python via Pyodide in headless Chromium (Node.js) | 5002 | `leg2_pyodide_chromium/run.sh` |
 | 3 | Rust compiled to `wasm32-wasip2`, served via `wasmtime serve` | 5003 | `leg3_wasmtime/run.sh` |
+| 4a | Flask + psycopg2 → Postgres (direct connection) | 5004 | `leg4a_flask_postgres/run.sh` |
+| 4b | Pyodide + Node.js pg bridge → Postgres (host bridge) | 5005 | `leg4b_wasm_postgres_bridge/run.sh` |
 
 Each leg can also be run standalone for debugging.
 

--- a/experiments/001_hello_world/benchmark.sh
+++ b/experiments/001_hello_world/benchmark.sh
@@ -31,11 +31,11 @@ now_ms() { python3 -c "import time; print(int(time.time()*1000))"; }
 
 # ── Helper: cold-start measurement ──────────────────────────────────────────
 cold_start_ms() {
-  local port=$1
+  local port=$1 path=${2:-/}
   local start end
   start=$(now_ms)
   for i in $(seq 1 100); do
-    curl -sf "http://127.0.0.1:$port/" &>/dev/null && break
+    curl -sf "http://127.0.0.1:$port$path" &>/dev/null && break
     sleep 0.1
   done
   end=$(now_ms)
@@ -115,9 +115,70 @@ RSS_3=$(rss_mb "$LEG3_PID")
 kill "$LEG3_PID" 2>/dev/null; wait "$LEG3_PID" 2>/dev/null || true
 ok "hey done  rss: ${RSS_3}MB  p50: $(hey_stat "$HEY_3" p50)ms  rps: $(hey_stat "$HEY_3" rps)"
 
+# ── POSTGRES: shared database for legs 4a/4b ─────────────────────────────────
+info "Starting Postgres for legs 4a/4b..."
+$CONTAINER_CMD rm -f bench-postgres &>/dev/null || true
+$CONTAINER_CMD run -d --name bench-postgres \
+  -e POSTGRES_USER=bench \
+  -e POSTGRES_PASSWORD=bench \
+  -e POSTGRES_DB=bench \
+  -p 5432:5432 \
+  docker.io/library/postgres:16-alpine &>/dev/null
+
+# Wait for Postgres to accept connections
+for i in $(seq 1 50); do
+  $CONTAINER_CMD exec bench-postgres pg_isready -U bench &>/dev/null && break
+  sleep 0.2
+done
+ok "Postgres ready"
+
+# Seed the items table
+$CONTAINER_CMD cp "$SCRIPT_DIR/shared/postgres_init.sql" bench-postgres:/tmp/init.sql
+$CONTAINER_CMD exec bench-postgres psql -U bench -d bench -f /tmp/init.sql &>/dev/null
+ok "Database seeded"
+
+# ── LEG 4a: Flask + psycopg2 / direct Postgres ──────────────────────────────
+info "Leg 4a: Flask + psycopg2 / direct (port 5004)"
+cd "$SCRIPT_DIR/leg4a_flask_postgres"
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+  .venv/bin/pip install --quiet flask psycopg2-binary
+fi
+ARTIFACT_4A=$(du -sh .venv 2>/dev/null | cut -f1)B
+
+.venv/bin/python app.py &
+LEG4A_PID=$!
+COLD_4A=$(cold_start_ms 5004 "/db?id=1")
+ok "cold start: ${COLD_4A}ms  artifact: $ARTIFACT_4A"
+
+HEY_4A=$(hey -n $HEY_N -c $HEY_C "http://127.0.0.1:5004/db?id=1")
+RSS_4A=$(rss_mb "$LEG4A_PID")
+kill "$LEG4A_PID" 2>/dev/null; wait "$LEG4A_PID" 2>/dev/null || true
+ok "hey done  rss: ${RSS_4A}MB  p50: $(hey_stat "$HEY_4A" p50)ms  rps: $(hey_stat "$HEY_4A" rps)"
+
+# ── LEG 4b: Node.js + Pyodide + pg bridge ───────────────────────────────────
+info "Leg 4b: Pyodide + pg bridge (port 5005)"
+cd "$SCRIPT_DIR/leg4b_wasm_postgres_bridge"
+[ -d node_modules ] || npm install --silent
+ARTIFACT_4B=$(du -sh node_modules 2>/dev/null | cut -f1)B
+
+node harness.js &
+LEG4B_PID=$!
+COLD_4B=$(cold_start_ms 5005 "/db?id=1")
+ok "cold start: ${COLD_4B}ms  artifact: $ARTIFACT_4B"
+
+HEY_4B=$(hey -n $HEY_N -c $HEY_C "http://127.0.0.1:5005/db?id=1")
+RSS_4B=$(rss_mb "$LEG4B_PID")
+kill "$LEG4B_PID" 2>/dev/null; wait "$LEG4B_PID" 2>/dev/null || true
+ok "hey done  rss: ${RSS_4B}MB  p50: $(hey_stat "$HEY_4B" p50)ms  rps: $(hey_stat "$HEY_4B" rps)"
+
+# ── Postgres cleanup ─────────────────────────────────────────────────────────
+$CONTAINER_CMD rm -f bench-postgres &>/dev/null
+ok "Postgres stopped"
+
 # ── Results table ─────────────────────────────────────────────────────────────
 echo ""
-echo "## Results"
+echo "## Results — Hello World (legs 1–3)"
 echo ""
 printf "| %-22s | %-20s | %-22s | %-16s |\n" "Metric" "Leg 1 Flask/Podman" "Leg 2 Pyodide/Chrome" "Leg 3 Wasmtime"
 printf "| %-22s | %-20s | %-22s | %-16s |\n" "---" "---" "---" "---"
@@ -127,4 +188,16 @@ printf "| %-22s | %-20s | %-22s | %-16s |\n" "Memory RSS (MB)"      "${RSS_1}"  
 printf "| %-22s | %-20s | %-22s | %-16s |\n" "hey p50 (ms)"         "$(hey_stat "$HEY_1" p50)"      "$(hey_stat "$HEY_2" p50)"       "$(hey_stat "$HEY_3" p50)"
 printf "| %-22s | %-20s | %-22s | %-16s |\n" "hey p99 (ms)"         "$(hey_stat "$HEY_1" p99)"      "$(hey_stat "$HEY_2" p99)"       "$(hey_stat "$HEY_3" p99)"
 printf "| %-22s | %-20s | %-22s | %-16s |\n" "hey req/s"            "$(hey_stat "$HEY_1" rps)"      "$(hey_stat "$HEY_2" rps)"       "$(hey_stat "$HEY_3" rps)"
+echo ""
+
+echo "## Results — Postgres DB query (legs 4a/4b)"
+echo ""
+printf "| %-22s | %-24s | %-24s |\n" "Metric" "Leg 4a Flask+psycopg2" "Leg 4b Pyodide+pg bridge"
+printf "| %-22s | %-24s | %-24s |\n" "---" "---" "---"
+printf "| %-22s | %-24s | %-24s |\n" "Artifact size"        "$ARTIFACT_4A"                    "$ARTIFACT_4B"
+printf "| %-22s | %-24s | %-24s |\n" "Cold start (ms)"      "${COLD_4A}"                       "${COLD_4B}"
+printf "| %-22s | %-24s | %-24s |\n" "Memory RSS (MB)"      "${RSS_4A}"                        "${RSS_4B}"
+printf "| %-22s | %-24s | %-24s |\n" "hey p50 (ms)"         "$(hey_stat "$HEY_4A" p50)"        "$(hey_stat "$HEY_4B" p50)"
+printf "| %-22s | %-24s | %-24s |\n" "hey p99 (ms)"         "$(hey_stat "$HEY_4A" p99)"        "$(hey_stat "$HEY_4B" p99)"
+printf "| %-22s | %-24s | %-24s |\n" "hey req/s"            "$(hey_stat "$HEY_4A" rps)"        "$(hey_stat "$HEY_4B" rps)"
 echo ""

--- a/experiments/001_hello_world/leg4a_flask_postgres/app.py
+++ b/experiments/001_hello_world/leg4a_flask_postgres/app.py
@@ -1,0 +1,49 @@
+import time
+
+from flask import Flask, jsonify, request
+from psycopg2 import pool
+
+app = Flask(__name__)
+
+db_pool = pool.SimpleConnectionPool(
+    1, 5,
+    host="127.0.0.1",
+    port=5432,
+    dbname="bench",
+    user="bench",
+    password="bench",
+)
+
+
+@app.route("/")
+def hello():
+    return jsonify({"message": "Hello World", "timestamp": time.time()})
+
+
+@app.route("/db")
+def db_query():
+    item_id = request.args.get("id", 1, type=int)
+    conn = db_pool.getconn()
+    try:
+        t0 = time.perf_counter()
+        with conn.cursor() as cur:
+            cur.execute("SELECT id, name, value FROM items WHERE id = %s", (item_id,))
+            row = cur.fetchone()
+        query_ms = (time.perf_counter() - t0) * 1000
+    finally:
+        db_pool.putconn(conn)
+
+    if row is None:
+        return jsonify({"error": "not found"}), 404
+
+    return jsonify({
+        "id": row[0],
+        "name": row[1],
+        "value": row[2],
+        "query_ms": round(query_ms, 3),
+        "timestamp": time.time(),
+    })
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5004)

--- a/experiments/001_hello_world/leg4a_flask_postgres/run.sh
+++ b/experiments/001_hello_world/leg4a_flask_postgres/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PORT=5004
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
+info() { echo -e "  ${YELLOW}→${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1" >&2; exit 1; }
+
+command -v python3 &>/dev/null || fail "python3 not found"
+
+cd "$SCRIPT_DIR"
+
+# Create venv if needed and install dependencies
+if [ ! -d .venv ]; then
+  info "Creating virtual environment..."
+  python3 -m venv .venv
+  .venv/bin/pip install --quiet flask psycopg2-binary
+fi
+
+info "Starting Flask + psycopg2 on port $PORT..."
+.venv/bin/python app.py &
+PID=$!
+
+for i in $(seq 1 50); do
+  curl -sf "http://127.0.0.1:$PORT/" &>/dev/null && break
+  sleep 0.2
+done
+
+ok "Listening on http://127.0.0.1:$PORT/"
+echo "  Try: curl http://127.0.0.1:$PORT/db?id=1"
+echo "  Stop: kill $PID"
+wait "$PID"

--- a/experiments/001_hello_world/leg4b_wasm_postgres_bridge/harness.js
+++ b/experiments/001_hello_world/leg4b_wasm_postgres_bridge/harness.js
@@ -1,0 +1,109 @@
+"use strict";
+
+const http = require("http");
+const { loadPyodide } = require("pyodide");
+const { Pool } = require("pg");
+
+const PORT = 5005;
+
+const pgPool = new Pool({
+  host: "127.0.0.1",
+  port: 5432,
+  database: "bench",
+  user: "bench",
+  password: "bench",
+  max: 5,
+});
+
+function parseId(url) {
+  const match = url.match(/[?&]id=(\d+)/);
+  return match ? parseInt(match[1], 10) : 1;
+}
+
+async function main() {
+  console.log("→ Loading Pyodide...");
+  const pyodide = await loadPyodide();
+
+  // Python handler: receives a pre-queried row from the host bridge.
+  // This mirrors real WASM components where the host provides I/O capabilities
+  // and the WASM module processes the result.
+  await pyodide.runPythonAsync(`
+import time
+import json
+
+def handle_hello(request_path):
+    return json.dumps({"message": "Hello World", "timestamp": time.time()})
+
+def handle_db(request_path, row):
+    """Format a DB result received via the host bridge."""
+    if row is None:
+        return json.dumps({"error": "not found"})
+
+    return json.dumps({
+        "id": row[0],
+        "name": row[1],
+        "value": row[2],
+        "query_ms": row[3],
+        "timestamp": time.time(),
+    })
+`);
+
+  const handleHelloFn = pyodide.globals.get("handle_hello");
+  const handleDbFn = pyodide.globals.get("handle_db");
+
+  // Verify Postgres is reachable
+  await pgPool.query("SELECT 1");
+  console.log("→ Postgres connection verified");
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      let body;
+
+      if (req.url.startsWith("/db")) {
+        // Host-side: perform the actual DB query (host-provided capability)
+        const itemId = parseId(req.url);
+        const t0 = process.hrtime.bigint();
+        const result = await pgPool.query(
+          "SELECT id, name, value FROM items WHERE id = $1",
+          [itemId]
+        );
+        const queryMs =
+          Number(process.hrtime.bigint() - t0) / 1_000_000;
+
+        const row = result.rows[0];
+        if (!row) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end('{"error":"not found"}');
+          return;
+        }
+
+        // Bridge: pass the query result into the WASM module (Pyodide)
+        const pyRow = pyodide.toPy([
+          row.id,
+          row.name,
+          row.value,
+          Math.round(queryMs * 1000) / 1000,
+        ]);
+        body = handleDbFn(req.url, pyRow);
+        pyRow.destroy();
+      } else {
+        body = handleHelloFn(req.url);
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(body);
+    } catch (err) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+
+  server.listen(PORT, "127.0.0.1", () => {
+    console.log(`→ Listening on http://127.0.0.1:${PORT}/`);
+  });
+}
+
+main().catch((err) => {
+  console.error("✗ Failed to start:", err);
+  process.exit(1);
+});

--- a/experiments/001_hello_world/leg4b_wasm_postgres_bridge/package.json
+++ b/experiments/001_hello_world/leg4b_wasm_postgres_bridge/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "leg4b-wasm-postgres-bridge",
+  "private": true,
+  "dependencies": {
+    "pg": "^8.13.0",
+    "pyodide": "^0.26.0"
+  }
+}

--- a/experiments/001_hello_world/leg4b_wasm_postgres_bridge/run.sh
+++ b/experiments/001_hello_world/leg4b_wasm_postgres_bridge/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PORT=5005
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
+info() { echo -e "  ${YELLOW}→${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1" >&2; exit 1; }
+
+command -v node &>/dev/null || fail "node not found — brew install node"
+command -v npm  &>/dev/null || fail "npm not found — brew install node"
+
+cd "$SCRIPT_DIR"
+[ -d node_modules ] || npm install --silent
+
+info "Starting Node.js + Pyodide + pg bridge on port $PORT..."
+node harness.js &
+PID=$!
+
+for i in $(seq 1 100); do
+  curl -sf "http://127.0.0.1:$PORT/" &>/dev/null && break
+  sleep 0.1
+done
+
+ok "Listening on http://127.0.0.1:$PORT/"
+echo "  Try: curl http://127.0.0.1:$PORT/db?id=1"
+echo "  Stop: kill $PID"
+wait "$PID"

--- a/experiments/001_hello_world/shared/postgres_init.sql
+++ b/experiments/001_hello_world/shared/postgres_init.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS items (
+    id    INTEGER PRIMARY KEY,
+    name  TEXT NOT NULL,
+    value INTEGER NOT NULL
+);
+
+INSERT INTO items (id, name, value) VALUES
+    (1, 'Item 1', 42),
+    (2, 'Item 2', 84),
+    (3, 'Item 3', 126),
+    (4, 'Item 4', 168),
+    (5, 'Item 5', 210)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

- Adds two new legs to experiment 001 measuring database access overhead through the WASM host bridge pattern
- **Leg 4a**: Flask + psycopg2 with direct Postgres connection (port 5004) — baseline
- **Leg 4b**: Node.js + Pyodide with host-provided `pg` bridge to Postgres (port 5005) — bridge pattern
- Shared Postgres 16-alpine container with seeded `items` table
- `benchmark.sh` extended with Postgres lifecycle management and separate results table
- README updated with H5/H6 hypotheses and legs 4a/4b

Closes #3

## Test plan

- [ ] `./install.sh` reports all prerequisites satisfied
- [ ] Postgres starts in Podman and seeds correctly
- [ ] `curl http://127.0.0.1:5004/db?id=1` returns JSON with query results (leg 4a)
- [ ] `curl http://127.0.0.1:5005/db?id=1` returns identical JSON shape (leg 4b)
- [ ] `./benchmark.sh` runs all 5 legs end-to-end and prints both results tables
- [ ] Postgres container is cleaned up after benchmark completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)