### PR TITLE
feat(003): transpose benchmark results table to one row per leg

### DIFF
--- a/experiments/001_hello_world/lib/bench.sh
+++ b/experiments/001_hello_world/lib/bench.sh
@@ -62,13 +62,14 @@ rss_mb() {
 
 # ── Parse hey output ──────────────────────────────────────────────────────────
 hey_stat() {
-  local out=$1 stat=$2
+  local out=$1 stat=$2 val
   case "$stat" in
-    p50) echo "$out" | grep "50%%" | awk '{printf "%.1f", $3*1000}' ;;
-    p95) echo "$out" | grep "95%%" | awk '{printf "%.1f", $3*1000}' ;;
-    p99) echo "$out" | grep "99%%" | awk '{printf "%.1f", $3*1000}' ;;
-    rps) echo "$out" | grep "Requests/sec:" | awk '{printf "%.0f", $2}' ;;
+    p50) val=$(echo "$out" | grep "50%%" | awk '{printf "%.1f", $3*1000}') ;;
+    p95) val=$(echo "$out" | grep "95%%" | awk '{printf "%.1f", $3*1000}') ;;
+    p99) val=$(echo "$out" | grep "99%%" | awk '{printf "%.1f", $3*1000}') ;;
+    rps) val=$(echo "$out" | grep "Requests/sec:" | awk '{printf "%.0f", $2}') ;;
   esac
+  echo "${val:-n/a}"
 }
 
 # ── Descendant PIDs (recursive) ──────────────────────────────────────────────

--- a/experiments/003_wasm_compile/benchmark.sh
+++ b/experiments/003_wasm_compile/benchmark.sh
@@ -279,38 +279,42 @@ run_leg4() {
 # Results table
 # ══════════════════════════════════════════════════════════════════════════════
 print_results() {
+  local fmt="| %-22s | %-8s | %-10s | %-10s | %-18s | %-10s | %-10s | %-10s | %-10s | %-8s |\n"
   echo ""
   echo "## Results — Experiment 003: JS, Python & AS → .wasm"
   echo ""
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Metric" \
-    "1a JS/Spin native" \
-    "1b JS/Spin podman" \
-    "2a Py/raw wasmtime" \
-    "2b Py/Spin native" \
-    "2c Py/Spin podman" \
-    "3 Rust baseline" \
-    "4 AS/wasmtime"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "---" "---" "---" "---" "---" "---" "---" "---"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Source size"       "${APP_1A:-n/a}"    "${APP_1B:-n/a}"    "${APP_2A:-n/a}"      "${APP_2B:-n/a}"    "${APP_2C:-n/a}"    "${APP_3:-n/a}"    "${APP_4:-n/a}"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Artifact (.wasm)"  "${ARTIFACT_1A:-n/a}" "${ARTIFACT_1B:-n/a}" "${ARTIFACT_2A:-n/a}" "${ARTIFACT_2B:-n/a}" "${ARTIFACT_2C:-n/a}" "${ARTIFACT_3:-n/a}" "${ARTIFACT_4:-n/a}"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Build time (ms)"   "${BUILD_1A:-n/a}"  "-"                 "${BUILD_2A:-n/a}"    "${BUILD_2B:-n/a}"  "-"                 "${BUILD_3:-n/a}"  "${BUILD_4:-n/a}"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Runtime/image"     "${RUNTIME_1A:-n/a}" "${RUNTIME_1B:-n/a}" "${RUNTIME_2A:-n/a}" "${RUNTIME_2B:-n/a}" "${RUNTIME_2C:-n/a}" "${RUNTIME_3:-n/a}" "${RUNTIME_4:-n/a}"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Cold start (ms)"   "${COLD_1A:-n/a}"   "${COLD_1B:-n/a}"   "${COLD_2A:-n/a}"     "${COLD_2B:-n/a}"   "${COLD_2C:-n/a}"   "${COLD_3:-n/a}"   "${COLD_4:-n/a}"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "Memory RSS (MB)"   "${RSS_1A:-n/a}"    "${RSS_1B:-n/a}"    "${RSS_2A:-n/a}"      "${RSS_2B:-n/a}"    "${RSS_2C:-n/a}"    "${RSS_3:-n/a}"    "${RSS_4:-n/a}"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "hey p50 (ms)"      "$(hey_stat "${HEY_1A:-}" p50)"  "$(hey_stat "${HEY_1B:-}" p50)"  "$(hey_stat "${HEY_2A:-}" p50)"  "$(hey_stat "${HEY_2B:-}" p50)"  "$(hey_stat "${HEY_2C:-}" p50)"  "$(hey_stat "${HEY_3:-}" p50)"  "$(hey_stat "${HEY_4:-}" p50)"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "hey p95 (ms)"      "$(hey_stat "${HEY_1A:-}" p95)"  "$(hey_stat "${HEY_1B:-}" p95)"  "$(hey_stat "${HEY_2A:-}" p95)"  "$(hey_stat "${HEY_2B:-}" p95)"  "$(hey_stat "${HEY_2C:-}" p95)"  "$(hey_stat "${HEY_3:-}" p95)"  "$(hey_stat "${HEY_4:-}" p95)"
-  printf "| %-22s | %-20s | %-20s | %-24s | %-20s | %-20s | %-18s | %-18s |\n" \
-    "hey req/s"         "$(hey_stat "${HEY_1A:-}" rps)"  "$(hey_stat "${HEY_1B:-}" rps)"  "$(hey_stat "${HEY_2A:-}" rps)"  "$(hey_stat "${HEY_2B:-}" rps)"  "$(hey_stat "${HEY_2C:-}" rps)"  "$(hey_stat "${HEY_3:-}" rps)"  "$(hey_stat "${HEY_4:-}" rps)"
+  printf "$fmt" \
+    "Leg" "Source" "Artifact" "Build(ms)" "Runtime" "Cold(ms)" "RSS(MB)" "p50(ms)" "p95(ms)" "req/s"
+  printf "$fmt" \
+    "---" "---" "---" "---" "---" "---" "---" "---" "---" "---"
+  printf "$fmt" "1a JS/Spin native" \
+    "${APP_1A:-n/a}" "${ARTIFACT_1A:-n/a}" "${BUILD_1A:-n/a}" "${RUNTIME_1A:-n/a}" \
+    "${COLD_1A:-n/a}" "${RSS_1A:-n/a}" \
+    "$(hey_stat "${HEY_1A:-}" p50)" "$(hey_stat "${HEY_1A:-}" p95)" "$(hey_stat "${HEY_1A:-}" rps)"
+  printf "$fmt" "1b JS/Spin podman" \
+    "${APP_1B:-n/a}" "${ARTIFACT_1B:-n/a}" "-" "${RUNTIME_1B:-n/a}" \
+    "${COLD_1B:-n/a}" "${RSS_1B:-n/a}" \
+    "$(hey_stat "${HEY_1B:-}" p50)" "$(hey_stat "${HEY_1B:-}" p95)" "$(hey_stat "${HEY_1B:-}" rps)"
+  printf "$fmt" "2a Py/raw wasmtime" \
+    "${APP_2A:-n/a}" "${ARTIFACT_2A:-n/a}" "${BUILD_2A:-n/a}" "${RUNTIME_2A:-n/a}" \
+    "${COLD_2A:-n/a}" "${RSS_2A:-n/a}" \
+    "$(hey_stat "${HEY_2A:-}" p50)" "$(hey_stat "${HEY_2A:-}" p95)" "$(hey_stat "${HEY_2A:-}" rps)"
+  printf "$fmt" "2b Py/Spin native" \
+    "${APP_2B:-n/a}" "${ARTIFACT_2B:-n/a}" "${BUILD_2B:-n/a}" "${RUNTIME_2B:-n/a}" \
+    "${COLD_2B:-n/a}" "${RSS_2B:-n/a}" \
+    "$(hey_stat "${HEY_2B:-}" p50)" "$(hey_stat "${HEY_2B:-}" p95)" "$(hey_stat "${HEY_2B:-}" rps)"
+  printf "$fmt" "2c Py/Spin podman" \
+    "${APP_2C:-n/a}" "${ARTIFACT_2C:-n/a}" "-" "${RUNTIME_2C:-n/a}" \
+    "${COLD_2C:-n/a}" "${RSS_2C:-n/a}" \
+    "$(hey_stat "${HEY_2C:-}" p50)" "$(hey_stat "${HEY_2C:-}" p95)" "$(hey_stat "${HEY_2C:-}" rps)"
+  printf "$fmt" "3 Rust baseline" \
+    "${APP_3:-n/a}" "${ARTIFACT_3:-n/a}" "${BUILD_3:-n/a}" "${RUNTIME_3:-n/a}" \
+    "${COLD_3:-n/a}" "${RSS_3:-n/a}" \
+    "$(hey_stat "${HEY_3:-}" p50)" "$(hey_stat "${HEY_3:-}" p95)" "$(hey_stat "${HEY_3:-}" rps)"
+  printf "$fmt" "4 AS/wasmtime" \
+    "${APP_4:-n/a}" "${ARTIFACT_4:-n/a}" "${BUILD_4:-n/a}" "${RUNTIME_4:-n/a}" \
+    "${COLD_4:-n/a}" "${RSS_4:-n/a}" \
+    "$(hey_stat "${HEY_4:-}" p50)" "$(hey_stat "${HEY_4:-}" p95)" "$(hey_stat "${HEY_4:-}" rps)"
   echo ""
 
   echo "### Hypothesis outcomes"

--- a/experiments/003_wasm_compile/benchmark.sh
+++ b/experiments/003_wasm_compile/benchmark.sh
@@ -137,7 +137,7 @@ run_leg2a() {
   pushd "$SCRIPT_DIR/python-raw" >/dev/null
     APP_2A=$(human_size app.py)
     BUILD_2A=$(timed_build "componentize-py" \
-      componentize-py -d wit -w proxy componentize app -o hello-py-raw.wasm 2>/dev/null)
+      componentize-py -d wit -w proxy componentize app -o hello-py-raw.wasm >/dev/null 2>&1)
     ARTIFACT_2A=$(human_size hello-py-raw.wasm)
     RUNTIME_2A="wasmtime $(wasmtime --version | awk '{print $2}')"
 


### PR DESCRIPTION
## Summary

- Transpose `print_results()` in `benchmark.sh` so each leg is a row and metrics are columns
- Table now has 10 columns (Leg + 9 metrics) and 7 data rows instead of 9 metric rows × 8 columns
- Build column shows `-` for container legs (1b, 2c) that reuse the native build
- Hypothesis table unchanged

Closes #21

## Test plan

- [x] `bash -n benchmark.sh` syntax check passes
- [x] Dry-run `print_results()` with empty vars renders cleanly
- [ ] `make bench-quick` runs and prints the transposed table

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)