### PR TITLE
chore: update NPM dependencies

### DIFF
--- a/experiments/001_hello_world/leg2a_pyodide_node/package.json
+++ b/experiments/001_hello_world/leg2a_pyodide_node/package.json
@@ -7,6 +7,6 @@
     "start": "node harness.js"
   },
   "dependencies": {
-    "pyodide": "0.26.4"
+    "pyodide": "314.0.2"
   }
 }

--- a/experiments/001_hello_world/leg2b_pyodide_chromium/package.json
+++ b/experiments/001_hello_world/leg2b_pyodide_chromium/package.json
@@ -7,6 +7,6 @@
     "start": "node harness.js"
   },
   "dependencies": {
-    "puppeteer": "^24.0.0"
+    "puppeteer": "^25.3.0"
   }
 }

--- a/experiments/001_hello_world/leg2c_pyodide_playwright/package.json
+++ b/experiments/001_hello_world/leg2c_pyodide_playwright/package.json
@@ -7,6 +7,6 @@
     "start": "node harness.js"
   },
   "dependencies": {
-    "playwright": "^1.50.0"
+    "playwright": "^1.61.1"
   }
 }

--- a/experiments/001_hello_world/leg4b_wasm_postgres_bridge/package.json
+++ b/experiments/001_hello_world/leg4b_wasm_postgres_bridge/package.json
@@ -2,7 +2,7 @@
   "name": "leg4b-wasm-postgres-bridge",
   "private": true,
   "dependencies": {
-    "pg": "8.13.0",
-    "pyodide": "0.26.0"
+    "pg": "8.22.0",
+    "pyodide": "314.0.2"
   }
 }

--- a/experiments/001_hello_world/leg4c_wasmtime_postgres/package.json
+++ b/experiments/001_hello_world/leg4c_wasmtime_postgres/package.json
@@ -2,6 +2,6 @@
   "name": "leg4c-wasmtime-postgres-sidecar",
   "private": true,
   "dependencies": {
-    "pg": "^8.13.0"
+    "pg": "^8.22.0"
   }
 }

--- a/experiments/002_chromium_sandbox/package.json
+++ b/experiments/002_chromium_sandbox/package.json
@@ -15,7 +15,7 @@
     "leg4b": "node harness.js 4b"
   },
   "dependencies": {
-    "pg": "^8.13.0",
-    "playwright": "^1.50.0"
+    "pg": "^8.22.0",
+    "playwright": "^1.61.1"
   }
 }

--- a/experiments/003_wasm_compile/as-hello/package.json
+++ b/experiments/003_wasm_compile/as-hello/package.json
@@ -5,6 +5,6 @@
     "asbuild": "asc assembly/index.ts --outFile build/hello-as-core.wasm --optimize --exportRuntime --lowMemoryLimit --use abort=assembly/index/abort"
   },
   "devDependencies": {
-    "assemblyscript": "^0.27.0"
+    "assemblyscript": "^0.28.20"
   }
 }

--- a/experiments/003_wasm_compile/js-spin/package.json
+++ b/experiments/003_wasm_compile/js-spin/package.json
@@ -7,12 +7,12 @@
     "build": "node build.mjs && mkdirp dist && j2w -i build/bundle.js --initLocation http://hello-js.localhost -o dist/hello-js.wasm"
   },
   "dependencies": {
-    "itty-router": "^5.0.18",
-    "@spinframework/build-tools": "^1.0.4",
-    "@spinframework/wasi-http-proxy": "^1.0.0"
+    "itty-router": "^5.0.24",
+    "@spinframework/build-tools": "^2.1.0",
+    "@spinframework/wasi-http-proxy": "^2.0.0"
   },
   "devDependencies": {
     "mkdirp": "^3.0.1",
-    "esbuild": "^0.25.8"
+    "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
Updates all NPM dependencies across the 8 `package.json` files in this repo to their latest versions (via `npm-check-updates`). No lockfiles were committed because `package-lock.json` is gitignored at the repo root.

## Updated packages

### experiments/001_hello_world/leg2a_pyodide_node
| Package | Old | New |
|---|---|---|
| pyodide | 0.26.4 | 314.0.2 |

### experiments/001_hello_world/leg2b_pyodide_chromium
| Package | Old | New |
|---|---|---|
| puppeteer | ^24.0.0 | ^25.3.0 |

### experiments/001_hello_world/leg2c_pyodide_playwright
| Package | Old | New |
|---|---|---|
| playwright | ^1.50.0 | ^1.61.1 |

### experiments/001_hello_world/leg4b_wasm_postgres_bridge
| Package | Old | New |
|---|---|---|
| pg | 8.13.0 | 8.22.0 |
| pyodide | 0.26.0 | 314.0.2 |

### experiments/001_hello_world/leg4c_wasmtime_postgres
| Package | Old | New |
|---|---|---|
| pg | ^8.13.0 | ^8.22.0 |

### experiments/002_chromium_sandbox
| Package | Old | New |
|---|---|---|
| pg | ^8.13.0 | ^8.22.0 |
| playwright | ^1.50.0 | ^1.61.1 |

### experiments/003_wasm_compile/as-hello
| Package | Old | New |
|---|---|---|
| assemblyscript | ^0.27.0 | ^0.28.20 |

### experiments/003_wasm_compile/js-spin
| Package | Old | New |
|---|---|---|
| @spinframework/build-tools | ^1.0.4 | ^2.1.0 |
| @spinframework/wasi-http-proxy | ^1.0.0 | ^2.0.0 |
| esbuild | ^0.25.8 | ^0.28.1 |
| itty-router | ^5.0.18 | ^5.0.24 |

## MAJOR version bumps (potentially breaking)

- **pyodide 0.26.x → 314.0.2** (leg2a, leg4b) — pyodide switched to CPython-aligned versioning (314 = Python 3.14). Verified legitimate on the npm registry (published from pyodide/pyodide). Large jump; API changes possible.
- **puppeteer ^24.0.0 → ^25.3.0** (leg2b)
- **@spinframework/build-tools ^1.0.4 → ^2.1.0** (js-spin)
- **@spinframework/wasi-http-proxy ^1.0.0 → ^2.0.0** (js-spin)
- **assemblyscript ^0.27.0 → ^0.28.20** (as-hello) — 0.x minor bump, potentially breaking under 0.x semver conventions
- **esbuild ^0.25.8 → ^0.28.1** (js-spin) — 0.x minor bump, potentially breaking under 0.x semver conventions

## Verification

- `npm install` succeeded in all 8 directories.
- `experiments/003_wasm_compile/js-spin`: `npm run build` — **PASS** (component built successfully with the new Spin v2 toolchain).
- `experiments/003_wasm_compile/as-hello`: `npm run asbuild` — **PASS** (compiled with assemblyscript 0.28).
- No other package defines a `build` or `test` script (remaining scripts are `start`/runtime harnesses), so no further automated verification was run. The pyodide 0.26 → 314 jump in particular was not runtime-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)