### PR TITLE
fix: resolve npm audit vulnerabilities

### DIFF
--- a/experiments/003_wasm_compile/js-spin/package.json
+++ b/experiments/003_wasm_compile/js-spin/package.json
@@ -14,5 +14,8 @@
   "devDependencies": {
     "mkdirp": "^3.0.1",
     "esbuild": "^0.25.8"
+  },
+  "overrides": {
+    "@bytecodealliance/jco": "~1.17.9"
   }
 }


### PR DESCRIPTION
## Summary

Security-only dependency update. All 8 `package.json` files under `experiments/` were audited (lockfiles are gitignored in this repo, so lockfiles were generated locally for auditing only — the committable fix is in `package.json`).

## Audit results per package

| package.json | Vulnerabilities before | Vulnerabilities after |
|---|---|---|
| experiments/001_hello_world/leg2a_pyodide_node | 0 | 0 |
| experiments/001_hello_world/leg2b_pyodide_chromium | 0 | 0 |
| experiments/001_hello_world/leg2c_pyodide_playwright | 0 | 0 |
| experiments/001_hello_world/leg4b_wasm_postgres_bridge | 0 | 0 |
| experiments/001_hello_world/leg4c_wasmtime_postgres | 0 | 0 |
| experiments/002_chromium_sandbox | 0 | 0 |
| experiments/003_wasm_compile/as-hello | 0 | 0 |
| **experiments/003_wasm_compile/js-spin** | **4 critical** | **0** |

## Fixed vulnerabilities (js-spin)

All 4 critical findings are one advisory chain rooted at `decompress`:

| Package | Severity | Advisory | Old (resolved) | New (resolved) |
|---|---|---|---|---|
| decompress | critical (CVSS 9.1) | [GHSA-mp2f-45pm-3cg9](https://github.com/advisories/GHSA-mp2f-45pm-3cg9) (CWE-22/59/732) | 4.2.1 | removed from tree |
| @bytecodealliance/weval | critical (via decompress) | same chain | 0.4.1 | removed from tree |
| @bytecodealliance/componentize-js | critical (via weval) | same chain | 0.21.0 | 0.19.3 |
| @bytecodealliance/jco | critical (via componentize-js) | same chain | 1.25.2 | 1.17.9 |

### Fix mechanism

`npm audit fix` could not resolve this (no non-vulnerable `decompress` release exists — the advisory covers `<=4.2.1`, i.e. every published version), and no direct-dependency bump helps: `@spinframework/build-tools` 2.1.0 (latest) still depends on vulnerable `componentize-js ^0.20.0` / `jco` resolving to 1.25.2. Since lockfiles are gitignored, a lockfile-only pin would not persist for consumers.

The committed fix adds an npm `overrides` entry to `experiments/003_wasm_compile/js-spin/package.json`:

```json
"overrides": { "@bytecodealliance/jco": "~1.17.9" }
```

jco 1.17.9 is the newest release outside the vulnerable range (`1.7.0 - 1.15.0 || >=1.18.0`); it pulls `componentize-js` 0.19.3 (last safe version, uses `wizer` instead of `weval`), which eliminates `weval` and `decompress` from the tree entirely. Direct dependency ranges are unchanged.

## Major bumps

None (no direct dependency versions changed; the override downgrades a transitive dependency within `build-tools`' declared range `^1.10.2`).

## Remaining / unfixable vulnerabilities

None. Note: the upstream chain (`jco >=1.18`, `componentize-js >=0.19.4-rc.1`, all `weval`) remains vulnerable until `decompress` ships a fix, so the override should stay until upstream resolves GHSA-mp2f-45pm-3cg9.

## Before/after totals

- Before: 4 critical, 0 high/moderate/low (across all 8 packages)
- After: 0

## Verification

- `npm audit`: 0 vulnerabilities in all 8 packages after fix
- `npm run build` in js-spin (the only package with a `build` script): **pass** — component compiled successfully with jco 1.17.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)