### PR TITLE
feat: experiment 005 — stdout/stderr capture under load

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Reference: [AWS's Stealth Container Killer](https://aws.plainenglish.io/awss-ste
 | [002](experiments/002_chromium_sandbox/) | chromium_sandbox | done | Chromium+Pyodide isolation strategies — worker pools, BrowserContext pooling, JS↔WASM bridge overhead |
 | [003](experiments/003_wasm_compile/) | wasm_compile | results pending | Compiling JS/Python/Rust to `.wasm` via Spin/componentize-py/cargo, native vs. podman |
 | [004](experiments/004_static_wasi_hello/) | static_wasi_hello | done | Static HTML page, zero server at execution time — `mvl-lang/mvl-playground`'s actual architecture |
+| [005](experiments/005_stdout_capture_load/) | stdout_capture_load | done | stdout/stderr capture correctness + overhead at 10/1,000/100,000 lines |
 
 ## Structure
 

--- a/experiments/005_stdout_capture_load/.gitignore
+++ b/experiments/005_stdout_capture_load/.gitignore
@@ -1,0 +1,4 @@
+# rust/target/, web/node_modules/, Cargo.lock, package-lock.json are already
+# covered by the repo-root .gitignore.
+web/vendor/
+web/line_flood.wasm

--- a/experiments/005_stdout_capture_load/README.md
+++ b/experiments/005_stdout_capture_load/README.md
@@ -1,0 +1,118 @@
+# Experiment 005 — stdout/stderr Capture Under Load
+
+Extends [experiment 004](../004_static_wasi_hello/)'s static-page architecture. Instead
+of one line, the WASM binary prints N lines to stdout and N to stderr, interleaved, in
+a tight loop — 10, 1,000, and 100,000 — to find where the capture pipeline
+(`browser_wasi_shim`'s `ConsoleStdout.lineBuffered` → one `postMessage` per line →
+main-thread handling) costs something, and whether it's ever wrong.
+
+Directly exercises the mechanism `mvl-lang/mvl-playground`'s Runtime output pane
+depends on, which is only manually spot-checked there today, never stress-tested.
+
+## Hypotheses
+
+| # | Hypothesis | Status |
+|---|-----------|--------|
+| H1 | Per-line overhead stays roughly constant (small but non-zero) as N grows | **Refuted.** Per-line cost drops from 0.0425ms at N=10 to 0.0016ms at N=100,000 — a ~26x decrease, not a constant. See Finding 1. |
+| H2 | stdout/stderr interleaving preserves per-stream ordering, but a cross-stream race is plausible | **Confirmed on ordering, not tested on interleaving-race specifically** — every run at every N had exact per-stream monotonic sequences (0..N-1, no gaps, no duplicates) across two independent `ConsoleStdout` callbacks. No cross-stream race was ever observed, but this doesn't rule one out under different scheduling — see Limitations. |
+| H3 | Naive per-message DOM rendering becomes the bottleneck before the Worker/shim pipeline does | **Confirmed, and precisely quantified** — at N=100,000, DOM append adds ~780ms on top of the array-only baseline (352ms → 1135ms); at N=10 and N=1,000 the difference is within measurement noise. See Finding 2. |
+| H4 | No lines are silently dropped, duplicated, or reordered at any tested N | **Confirmed at every tested N**, up to 200,000 total captured lines. |
+
+## Methodology
+
+- **Correctness**: each line is `OUT <i>` or `ERR <i>`, `i` a monotonic per-stream
+  counter. The browser-side harness parses every received line back into its sequence
+  number and checks `seq[k] === k` for all `k` — an exact-match check, not just a
+  count.
+- **Timing, two numbers per run, not one:**
+  - `workerElapsedMs` — measured **inside the Worker**, wrapping only `wasi.start(instance)`. Covers WASM execution plus the N synchronous `postMessage` dispatch calls (structured-clone serialization). Does **not** include `fetch`/`WebAssembly.instantiate` or any main-thread work.
+  - `mainThreadElapsedMs` — measured **on the main thread**, from just before `worker.postMessage({type:'run'})` to the last stdout/stderr message received. Includes fetch, instantiate, full execution, message-passing latency, and (when enabled) DOM rendering. This is closer to "how long until the user sees everything" than `workerElapsedMs` is.
+- **DOM variants**: `?dom=1` appends one DOM node per received line (naive); `?dom=0` only counts/verifies in memory and renders one summary line at the end. Both always run the full correctness check.
+- **Each measurement launches a fresh headless Chromium process** (`chromium.launch()` per `measure.mjs` invocation) — there is no shared warm browser across the N×dom matrix. This is a real limitation: small-N numbers are more exposed to fixed one-time costs (first navigation, JIT warmup — the same effect documented in experiment 004) than large-N numbers are, since the fixed cost is a smaller fraction of a bigger total. Finding 1 is best read with this in mind.
+
+## Findings
+
+### 1. Per-line overhead is dominated by a fixed cost, not a per-call cost — H1 refuted
+
+| N | Total lines | Worker-side (ms) | ms/line |
+|---|---|---|---|
+| 10 | 20 | 0.85 | 0.0425 |
+| 1,000 | 2,000 | 6.55 | 0.0033 |
+| 100,000 | 200,000 | 326.75 | 0.0016 |
+
+If `postMessage` cost per line were roughly constant, ms/line would stay flat across
+the table. It drops by an order of magnitude from N=10 to N=1,000, then keeps
+dropping (more slowly) to N=100,000. The honest read: there is a small fixed
+per-run cost (browser/JIT warmup, consistent with experiment 004's own first-run
+outlier) that dominates the N=10 case and amortizes away as N grows. **The
+practical implication for a real playground is the opposite of the original
+worry**: printing more lines doesn't get proportionally more expensive per line —
+if anything it gets cheaper per line, up to whatever point DOM rendering (Finding 2)
+takes over as the actual bottleneck.
+
+### 2. DOM rendering, not the shim/postMessage pipeline, is the real cost at scale — H3 confirmed
+
+| N | dom | Total lines | Worker-side (ms) | Main-thread total (ms) |
+|---|---|---|---|---|
+| 10 | 1 | 20 | 0.9 | 36.0 |
+| 10 | 0 | 20 | 0.8 | 13.5 |
+| 1,000 | 1 | 2,000 | 7.1 | 25.5 |
+| 1,000 | 0 | 2,000 | 6.0 | 24.3 |
+| 100,000 | 1 | 200,000 | 337.6 | 1,134.8 |
+| 100,000 | 0 | 200,000 | 315.9 | 352.2 |
+
+At N=10 and N=1,000 the dom=1 vs dom=0 difference is within noise (a few ms, likely
+the fresh-browser-per-run effect from Finding 1, not DOM cost specifically). At
+N=100,000 it is not noise: **naive per-line DOM append adds ~780ms** (352ms → 1,135ms,
+a >3x increase) while the worker-side WASM execution time barely moves (316ms →
+338ms). The pipeline that captures and delivers output is not what gets slow — 200,000
+individually-appended DOM nodes is.
+
+Notably, it does **not** hang or time out even at 200,000 nodes in headless
+Chromium (60s budget, completed in ~1.1s) — slower, not broken.
+
+### 3. Zero drops, duplicates, or reordering at any tested scale — H4 confirmed
+
+Every run, every N, both dom variants: exact per-stream sequence match, exact line
+counts, zero console errors. The capture pipeline's correctness held up to 200,000
+total lines; nothing here suggests it would fail at even higher N, though this wasn't
+tested past 100,000/stream.
+
+## Limitations
+
+- H2's "cross-stream race" was never observed, but this experiment doesn't
+  specifically try to provoke one (e.g. by making one stream's writes artificially
+  slower than the other's). Absence of evidence here is not strong evidence of
+  absence.
+- No shared-browser, multi-trial-per-N measurement was done (see Methodology) — the
+  N=10 numbers in particular should be read as "N=10 in a freshly launched browser,"
+  not "the true asymptotic per-line cost at N=10."
+
+## Usage
+
+```bash
+./build.sh
+./benchmark.sh                 # full N x dom matrix, ~10-15s total
+
+# Manual:
+python3 -m http.server 8899 --bind 127.0.0.1 --directory web
+open "http://127.0.0.1:8899/index.html?n=1000&dom=1"
+```
+
+## Structure
+
+```
+005_stdout_capture_load/
+├── README.md
+├── build.sh
+├── benchmark.sh              # runs N=10/1000/100000 x dom=0/1, verifies + reports
+├── rust/
+│   ├── Cargo.toml
+│   └── src/main.rs           # prints N interleaved, per-stream-sequenced lines
+└── web/
+    ├── index.html            # ?n=&dom= query params; verifies + times in-page
+    ├── worker.js
+    ├── measure.mjs           # Playwright: one (N, dom) measurement
+    └── package.json
+    # web/vendor/, web/line_flood.wasm, web/node_modules/ — build.sh output, gitignored
+```

--- a/experiments/005_stdout_capture_load/benchmark.sh
+++ b/experiments/005_stdout_capture_load/benchmark.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# benchmark.sh — runs the full N x dom matrix and reports timing + correctness.
+#
+# Each measurement launches a fresh headless Chromium instance (Playwright's
+# chromium.launch() per invocation of measure.mjs) — there is no shared warm
+# browser across the matrix. That's a deliberate limitation, not an oversight:
+# see README "Methodology" for what this does and doesn't let you compare.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ../001_hello_world/lib/bench.sh
+
+PORT=8899
+NS=(10 1000 100000)
+DOMS=(1 0)
+TIMEOUT_MS=60000
+
+info "Building..."
+./build.sh >/dev/null
+
+require_port_free "$PORT" "experiment 005 static server"
+python3 -m http.server "$PORT" --bind 127.0.0.1 --directory web >/tmp/exp005_server.log 2>&1 &
+SERVER_PID=$!
+trap 'kill_and_wait "$SERVER_PID"' EXIT
+wait_for_http "$PORT" "/index.html?n=1&dom=0" 5 "static server"
+
+echo
+printf "%-8s %-5s %-9s %-14s %-16s %-10s\n" "N" "dom" "ok" "worker(ms)" "mainThread(ms)" "lines"
+printf "%-8s %-5s %-9s %-14s %-16s %-10s\n" "-" "---" "--" "----------" "--------------" "-----"
+
+RESULTS=""
+for n in "${NS[@]}"; do
+  for dom in "${DOMS[@]}"; do
+    out=$(cd web && node measure.mjs "http://127.0.0.1:$PORT" "$n" "$dom" "$TIMEOUT_MS")
+    ok=$(echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('ok'))")
+    timed_out=$(echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('timedOut', False))")
+    if [ "$timed_out" = "True" ]; then
+      printf "%-8s %-5s %-9s %-14s %-16s %-10s\n" "$n" "$dom" "TIMEOUT" "-" "-" "-"
+      RESULTS="${RESULTS}| $n | $dom | **timed out (>${TIMEOUT_MS}ms)** | | | |\n"
+      continue
+    fi
+    worker_ms=$(echo "$out" | python3 -c "import json,sys; print(f\"{json.load(sys.stdin)['workerElapsedMs']:.1f}\")")
+    main_ms=$(echo "$out" | python3 -c "import json,sys; print(f\"{json.load(sys.stdin)['mainThreadElapsedMs']:.1f}\")")
+    total_lines=$(( n * 2 ))
+    printf "%-8s %-5s %-9s %-14s %-16s %-10s\n" "$n" "$dom" "$ok" "$worker_ms" "$main_ms" "$total_lines"
+    if [ "$ok" != "True" ]; then
+      fail "N=$n dom=$dom did not verify: $out"
+      exit 1
+    fi
+    RESULTS="${RESULTS}| $n | $dom | $total_lines | $worker_ms | $main_ms |\n"
+  done
+done
+
+echo
+ok "all correctness checks passed (per-stream monotonic sequence, exact counts, no console errors)"
+echo
+echo "## Results — experiment 005"
+echo
+echo "| N (lines/stream) | dom | total lines | worker-side (ms) | main-thread total (ms) |"
+echo "|---|---|---|---|---|"
+echo -e "$RESULTS"

--- a/experiments/005_stdout_capture_load/build.sh
+++ b/experiments/005_stdout_capture_load/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "→ Compiling rust/ to wasm32-wasip1..."
+(cd rust && cargo build --target wasm32-wasip1 --release)
+cp rust/target/wasm32-wasip1/release/line_flood.wasm web/line_flood.wasm
+echo "  wrote web/line_flood.wasm ($(wc -c < web/line_flood.wasm) bytes)"
+
+echo "→ Installing + vendoring @bjorn3/browser_wasi_shim..."
+(cd web && npm install --no-audit --no-fund >/dev/null)
+rm -rf web/vendor
+mkdir -p web/vendor/browser_wasi_shim
+cp web/node_modules/@bjorn3/browser_wasi_shim/dist/*.js web/vendor/browser_wasi_shim/
+
+echo "→ Done."

--- a/experiments/005_stdout_capture_load/rust/Cargo.toml
+++ b/experiments/005_stdout_capture_load/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "line_flood"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "line_flood"
+path = "src/main.rs"
+
+[profile.release]
+opt-level = "z"
+lto = true
+strip = true

--- a/experiments/005_stdout_capture_load/rust/src/main.rs
+++ b/experiments/005_stdout_capture_load/rust/src/main.rs
@@ -1,0 +1,17 @@
+// Experiment 005 — prints N lines interleaved across stdout/stderr, each
+// carrying a per-stream monotonic sequence number, so the browser-side
+// harness can verify completeness and ordering rather than just counting
+// lines received.
+use std::env;
+
+fn main() {
+    let n: u64 = env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
+    for i in 0..n {
+        println!("OUT {i}");
+        eprintln!("ERR {i}");
+    }
+}

--- a/experiments/005_stdout_capture_load/web/index.html
+++ b/experiments/005_stdout_capture_load/web/index.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Experiment 005 — stdout/stderr capture under load</title>
+<style>
+  body { font-family: ui-monospace, monospace; background: #111; color: #ddd; padding: 2rem; }
+  #out { white-space: pre-wrap; border: 1px solid #444; padding: 1rem; max-height: 40vh; overflow: auto; }
+  .stderr { color: #f66; }
+  #status { color: #6f6; margin-top: 1rem; }
+</style>
+</head>
+<body>
+<h1>Experiment 005 — stdout/stderr capture under load</h1>
+<p>
+  Query params: <code>?n=1000&amp;dom=1</code> — <code>n</code> = lines per stream (total
+  captured lines = 2n, stdout+stderr interleaved); <code>dom=1</code> appends every
+  received line to the DOM (naive), <code>dom=0</code> only counts/verifies it in memory
+  and renders a summary once at the end. Both variants always verify correctness.
+</p>
+<div id="out"></div>
+<div id="status">running…</div>
+
+<script type="module">
+  const params = new URLSearchParams(location.search);
+  const n = parseInt(params.get("n") || "10", 10);
+  const renderDom = params.get("dom") !== "0";
+
+  window.__exp005 = {
+    done: false,
+    error: null,
+    n,
+    renderDom,
+    // Timing
+    mainThreadStartMs: null,   // performance.now() when the run message was sent
+    firstMsgMs: null,          // performance.now() at first stdout/stderr message received
+    lastMsgMs: null,           // performance.now() at last stdout/stderr message received
+    workerElapsedMs: null,     // reported by the worker itself (WASM exec + postMessage dispatch)
+    // Correctness
+    stdoutSeq: [],
+    stderrSeq: [],
+    stdoutCount: 0,
+    stderrCount: 0,
+  };
+
+  const out = document.getElementById("out");
+  const status = document.getElementById("status");
+
+  function parseSeq(line, prefix) {
+    // Lines look like "OUT 42" / "ERR 42".
+    if (!line.startsWith(prefix)) return null;
+    const n = parseInt(line.slice(prefix.length + 1), 10);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function checkMonotonic(seqArray) {
+    for (let i = 0; i < seqArray.length; i++) {
+      if (seqArray[i] !== i) return { ok: false, firstBreakAt: i, expected: i, got: seqArray[i] };
+    }
+    return { ok: true };
+  }
+
+  const worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
+
+  worker.onmessage = (e) => {
+    const msg = e.data;
+    const now = performance.now();
+
+    if (msg.type === "stdout" || msg.type === "stderr") {
+      if (window.__exp005.firstMsgMs === null) window.__exp005.firstMsgMs = now;
+      window.__exp005.lastMsgMs = now;
+
+      if (msg.type === "stdout") {
+        window.__exp005.stdoutCount++;
+        const seq = parseSeq(msg.line, "OUT");
+        if (seq !== null) window.__exp005.stdoutSeq.push(seq);
+      } else {
+        window.__exp005.stderrCount++;
+        const seq = parseSeq(msg.line, "ERR");
+        if (seq !== null) window.__exp005.stderrSeq.push(seq);
+      }
+
+      if (renderDom) {
+        const span = document.createElement("div");
+        if (msg.type === "stderr") span.className = "stderr";
+        span.textContent = msg.line;
+        out.appendChild(span);
+      }
+    } else if (msg.type === "done") {
+      window.__exp005.done = true;
+      window.__exp005.exitCode = msg.exitCode;
+      window.__exp005.workerElapsedMs = msg.workerElapsedMs;
+      window.__exp005.stdoutCheck = checkMonotonic(window.__exp005.stdoutSeq);
+      window.__exp005.stderrCheck = checkMonotonic(window.__exp005.stderrSeq);
+      const mainMs = window.__exp005.lastMsgMs - window.__exp005.mainThreadStartMs;
+      status.textContent = renderDom
+        ? `done — ${window.__exp005.stdoutCount + window.__exp005.stderrCount} lines, main-thread ${mainMs.toFixed(1)}ms (dom=1)`
+        : `done — ${window.__exp005.stdoutCount + window.__exp005.stderrCount} lines, main-thread ${mainMs.toFixed(1)}ms (dom=0)`;
+      if (!renderDom) {
+        out.textContent = `[dom=0 — ${window.__exp005.stdoutCount} stdout + ${window.__exp005.stderrCount} stderr lines captured, not individually rendered]`;
+      }
+      document.body.setAttribute("data-exp005-done", "true");
+    } else if (msg.type === "error") {
+      window.__exp005.done = true;
+      window.__exp005.error = msg.message;
+      status.textContent = `error: ${msg.message}`;
+      status.style.color = "#f66";
+      document.body.setAttribute("data-exp005-done", "true");
+    }
+  };
+
+  window.__exp005.mainThreadStartMs = performance.now();
+  worker.postMessage({ type: "run", n });
+</script>
+</body>
+</html>

--- a/experiments/005_stdout_capture_load/web/measure.mjs
+++ b/experiments/005_stdout_capture_load/web/measure.mjs
@@ -1,0 +1,51 @@
+// measure.mjs — one run at a given N and dom flag.
+// Usage: node measure.mjs <baseUrl> <n> <dom: 0|1> [timeoutMs]
+import { chromium } from "playwright";
+
+const baseUrl = process.argv[2] || "http://127.0.0.1:8899";
+const n = process.argv[3] || "10";
+const dom = process.argv[4] || "1";
+const timeoutMs = parseInt(process.argv[5] || "30000", 10);
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const consoleErrors = [];
+page.on("pageerror", (e) => consoleErrors.push(String(e.message)));
+
+let timedOut = false;
+try {
+  await page.goto(`${baseUrl}/index.html?n=${n}&dom=${dom}`, { waitUntil: "commit" });
+  await page.waitForSelector('[data-exp005-done="true"]', { timeout: timeoutMs });
+} catch (e) {
+  timedOut = true;
+}
+
+const result = timedOut ? null : await page.evaluate(() => window.__exp005);
+await browser.close();
+
+if (timedOut) {
+  console.log(JSON.stringify({ ok: false, timedOut: true, n: Number(n), dom }));
+  process.exit(0); // a timeout is itself a valid, reportable measurement outcome
+}
+
+const expectedCount = Number(n);
+const correctness =
+  result.stdoutCount === expectedCount &&
+  result.stderrCount === expectedCount &&
+  result.stdoutCheck.ok &&
+  result.stderrCheck.ok &&
+  !result.error &&
+  consoleErrors.length === 0;
+
+console.log(JSON.stringify({
+  ok: correctness,
+  n: expectedCount,
+  dom: Number(dom),
+  stdoutCount: result.stdoutCount,
+  stderrCount: result.stderrCount,
+  stdoutCheck: result.stdoutCheck,
+  stderrCheck: result.stderrCheck,
+  workerElapsedMs: result.workerElapsedMs,
+  mainThreadElapsedMs: result.lastMsgMs - result.mainThreadStartMs,
+  consoleErrors,
+}));

--- a/experiments/005_stdout_capture_load/web/package.json
+++ b/experiments/005_stdout_capture_load/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "experiment-005-stdout-capture-load",
+  "version": "1.0.0",
+  "description": "stdout/stderr capture correctness and overhead under load",
+  "type": "module",
+  "scripts": {
+    "measure": "node measure.mjs"
+  },
+  "dependencies": {
+    "@bjorn3/browser_wasi_shim": "0.4.2"
+  },
+  "devDependencies": {
+    "playwright": "1.61.1"
+  }
+}

--- a/experiments/005_stdout_capture_load/web/worker.js
+++ b/experiments/005_stdout_capture_load/web/worker.js
@@ -1,0 +1,38 @@
+// worker.js — runs line_flood.wasm, printing N interleaved stdout/stderr
+// lines. One postMessage per captured line (deliberately not batched —
+// the point is to measure per-message overhead, not hide it).
+import { WASI, File, OpenFile, ConsoleStdout } from "./vendor/browser_wasi_shim/index.js";
+
+self.onmessage = async (e) => {
+  if (e.data?.type !== "run") return;
+  const n = e.data.n;
+
+  const wasi = new WASI(
+    ["line_flood", String(n)],
+    [],
+    [
+      new OpenFile(new File([])),
+      ConsoleStdout.lineBuffered((msg) => self.postMessage({ type: "stdout", line: msg })),
+      ConsoleStdout.lineBuffered((msg) => self.postMessage({ type: "stderr", line: msg })),
+    ],
+  );
+
+  try {
+    const resp = await fetch(new URL("./line_flood.wasm", import.meta.url));
+    const bytes = await resp.arrayBuffer();
+    const { instance } = await WebAssembly.instantiate(bytes, {
+      wasi_snapshot_preview1: wasi.wasiImport,
+    });
+
+    // Worker-side elapsed time: WASM execution + N synchronous postMessage
+    // dispatch calls (structured-clone serialization), NOT main-thread
+    // message handling or DOM work, which happens after this returns.
+    const workerStart = performance.now();
+    const exitCode = wasi.start(instance);
+    const workerElapsedMs = performance.now() - workerStart;
+
+    self.postMessage({ type: "done", exitCode, workerElapsedMs });
+  } catch (err) {
+    self.postMessage({ type: "error", message: String(err && err.message || err) });
+  }
+};


### PR DESCRIPTION
## Summary

Closes #27. Extends experiment 004's static-page architecture: instead of one line, `line_flood.wasm` prints N interleaved, per-stream-sequenced lines to stdout/stderr (10 / 1,000 / 100,000), to find where the Worker → shim → postMessage → main-thread pipeline costs something, and whether it's ever wrong.

## Two timing numbers per run, not one

- `workerElapsedMs` — wraps only `wasi.start()`: WASM execution + N synchronous `postMessage` dispatch calls
- `mainThreadElapsedMs` — full wall time from run-sent to last-message-received, including fetch/instantiate/DOM

Two DOM variants (`?dom=1` naive per-line append, `?dom=0` array-only) to separate pipeline cost from rendering cost.

## One hypothesis refuted, reported as such

Per-line worker-side overhead does **not** stay roughly constant as N grows — it drops from 0.0425ms/line at N=10 to 0.0016ms/line at N=100,000, a ~26x decrease. A fixed per-run cost (browser/JIT warmup, the same effect experiment 004 found) dominates small N and amortizes away at scale.

## DOM rendering, not the pipeline, is the real cost at scale

At N=100,000, naive per-line append adds **~780ms** on top of the array-only baseline (352ms → 1,135ms), while worker-side WASM execution barely moves (316ms → 338ms). It does not hang or time out even at 200,000 DOM nodes in headless Chromium — slower, not broken.

## Correctness

Zero drops, duplicates, or reordering at any tested N, up to 200,000 total captured lines — verified via exact per-stream monotonic sequence checks (`seq[k] === k`), not just line counts.

## Changes

### Added
- `experiments/005_stdout_capture_load/` — Rust line-flood binary, N×dom benchmark matrix, Playwright measurement harness

### Fixed
- Top-level `README.md` experiment table to include #005

## Testing

- [x] `./benchmark.sh` runs the full N×dom matrix (6 runs), all pass correctness
- [x] Clean-room rebuild reproduces the same qualitative findings (100% correctness both runs; DOM-dominance and per-line-cost-decreases-with-scale both hold), with the exact run-to-run variance the README's own Limitations section anticipates

## Related Issues

Closes #27.

---
🤖 *Generated with [Claude Code](https://claude.ai/code)*