### PR TITLE
feat: experiment 007 — custom minimal runtime vs. embedded interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Reference: [AWS's Stealth Container Killer](https://aws.plainenglish.io/awss-ste
 | [004](experiments/004_static_wasi_hello/) | static_wasi_hello | done | Static HTML page, zero server at execution time — `mvl-lang/mvl-playground`'s actual architecture |
 | [005](experiments/005_stdout_capture_load/) | stdout_capture_load | done | stdout/stderr capture correctness + overhead at 10/1,000/100,000 lines |
 | [006](experiments/006_worker_kill_switch/) | worker_kill_switch | done | `Worker.terminate()` against a genuine infinite loop — is it actually instant? (No — ~2.1s) |
+| [007](experiments/007_custom_runtime_vs_interpreter/) | custom_runtime_vs_interpreter | done | Hand-written 78-line JS runtime shim vs. componentize-py vs. Pyodide — artifact size, cold start, build complexity |
 
 ## Structure
 

--- a/experiments/001_hello_world/lib/bench.sh
+++ b/experiments/001_hello_world/lib/bench.sh
@@ -38,14 +38,28 @@ now_ms() { python3 -c "import time; print(int(time.time()*1000))"; }
 # Usage: cold_start_ms <port> [path] [timeout_seconds]
 cold_start_ms() {
   local port=$1 path=${2:-/} timeout=${3:-10}
-  local start end iterations
+  local start end iterations succeeded=0
   iterations=$(( timeout * 10 ))  # 0.1s per iteration
   start=$(now_ms)
   for i in $(seq 1 "$iterations"); do
-    curl -sf "http://127.0.0.1:$port$path" &>/dev/null && break
+    if curl -sf "http://127.0.0.1:$port$path" &>/dev/null; then
+      succeeded=1
+      break
+    fi
     sleep 0.1
   done
   end=$(now_ms)
+  # Found and fixed in experiment 007: this previously had no
+  # success/failure signal at all -- if the server never came up, the loop
+  # fell through and printed the full timeout budget as if it were a real
+  # cold-start measurement (silently fabricating a number, exactly the
+  # "captured the wrong exit code" failure shape). Now it fails loudly:
+  # empty stdout, non-zero exit, and a stderr message naming the timeout,
+  # rather than a number indistinguishable from a real measurement.
+  if [ "$succeeded" -ne 1 ]; then
+    fail "cold_start_ms: port $port$path never responded within ${timeout}s"
+    return 1
+  fi
   echo $(( end - start ))
 }
 

--- a/experiments/007_custom_runtime_vs_interpreter/.gitignore
+++ b/experiments/007_custom_runtime_vs_interpreter/.gitignore
@@ -1,0 +1,2 @@
+# rust/target/, node_modules/, Cargo.lock, package-lock.json are already
+# covered by the repo-root .gitignore.

--- a/experiments/007_custom_runtime_vs_interpreter/README.md
+++ b/experiments/007_custom_runtime_vs_interpreter/README.md
@@ -1,0 +1,147 @@
+# Experiment 007 — Custom Minimal Runtime vs. Embedded Interpreter
+
+`mvl-lang/mvl-playground` doesn't embed an existing language interpreter into WASM at
+all. It ships a hand-written JavaScript object (~60 functions: string/array/option/
+result/map operations) as a custom `"runtime"` import namespace that the compiled WASM
+module calls directly — a much lighter-weight strategy than embedding CPython
+(`componentize-py`, experiment 003's Python legs) or a full Python-in-WASM runtime
+(Pyodide, experiments 001/002). This experiment compares all three along artifact
+size, cold start, and build complexity — gathered directly, not assumed from other
+experiments' result tables (both 001's and 003's were still blank
+`<!-- populated by benchmark.sh -->` placeholders as of this writing).
+
+**This is not an apples-to-apples functional comparison.** componentize-py and
+Pyodide serve the same "Hello World" JSON HTTP handler as experiments 001/003. The
+custom-runtime leg does a much smaller thing — one string concatenation via a
+handle-based JS shim — because that's the actual shape of what mvl-playground does
+(one operation, backed by a hand-written import), not a full HTTP server. The
+comparison is about runtime/artifact/complexity characteristics of three strategies
+for "how does the language's behavior reach the sandbox," not identical workloads.
+
+## Results
+
+| Leg | Artifact size | Cold start | Hand-written runtime code | External toolchain |
+|---|---|---|---|---|
+| custom_runtime | 302 bytes | 0.28ms | 41 (Rust) + 37 (JS) = 78 lines | `rustc` + `wasm32-unknown-unknown` (stock, no extra install) |
+| componentize-py | 17.6MB | **N/A — see Finding 2** | 0 lines (embeds CPython) | `componentize-py` PyPI package + 7-line hand-authored WIT (+ ~3,000 lines of vendored WASI world definitions, not hand-authored) |
+| Pyodide | 11.9MB (core `.wasm` + stdlib zip) | 845ms | 0 lines (embeds CPython) | npm `pyodide` package |
+
+## Hypotheses
+
+| # | Hypothesis | Status |
+|---|-----------|--------|
+| H1 | Custom minimal runtime produces the smallest artifact by a wide margin | **Confirmed, dramatically** — 302 bytes vs. 11.9MB (Pyodide) vs. 17.6MB (componentize-py). ~39,000x and ~58,000x smaller respectively. |
+| H2 | Custom minimal runtime has the fastest cold start | **Confirmed for Pyodide (0.28ms vs. 845ms); unresolved for componentize-py** — its cold start could not be measured in this environment (Finding 2), not because it was fast, but because it never ran. |
+| H3 | The cost of "custom minimal runtime" is build/maintenance complexity, not runtime performance | **Confirmed, precisely quantified in Finding 3** — every operation needs hand-written code on both the WASM side and the JS-import side; an embedded interpreter gets its standard library for free at the cost of size and cold start. |
+| H4 | componentize-py sits between Pyodide and the custom runtime on both axes | **Refuted on artifact size (componentize-py is larger, not in-between); untestable on cold start** (Finding 2) |
+
+## Findings
+
+### 1. The size gap is not close
+
+302 bytes vs. multi-megabyte. This isn't "smaller" — it's a different category. The
+302-byte module has no standard library, no interpreter, no string/collection
+machinery of its own; every one of those things it needs, it asks the host for, one
+call at a time. That's the entire trade being measured.
+
+### 2. componentize-py's cold start could not be measured — a real environment gap, reported rather than hidden
+
+Built successfully (`componentize-py -d wit -w proxy componentize app -o
+hello-py-raw.wasm`, ~3s, 17.6MB output — this part works and the artifact size is
+real). Running it via `wasmtime serve` (the exact command experiment 003's own
+`python-raw/app.py` documents) fails immediately:
+
+```
+Error: component imports instance `wasi:cli/environment@0.2.4`, but a matching implementation was not found in the linker
+Caused by:
+    0: instance export `get-environment` has the wrong type
+    1: function implementation is missing
+```
+
+This is a WASI Preview2 world-version mismatch between the locally installed
+`wasmtime` (43.0.1) and whatever WASI snapshot `componentize-py`'s generated bindings
+target — a real, environment-specific toolchain compatibility gap, not a bug in the
+artifact itself. Tried the `python-spin` leg as an alternative runtime path (Spin
+bundles its own wasmtime, decoupled from the system one) and hit a **second,
+pre-existing gap**: `python-spin/` has no `wit/` directory tracked in the repo at
+all, so `spin build` fails with `AssertionError: failed to read path for WIT [wit]`
+before it can even try. Neither of these was introduced by this experiment; both are
+reported here because gathering real numbers is what surfaced them — reused, not
+duplicated, matching this experiment's own scope constraint against rebuilding
+experiment 003 from scratch. Filing both as follow-up observations for whoever
+next works on experiment 003, not fixed here.
+
+### 3. Build complexity, quantified
+
+| Leg | What you write | What you get for free |
+|---|---|---|
+| custom_runtime | Every operation (78 lines total for one string-concat op) | Nothing — no stdlib, no GC, no interpreter |
+| componentize-py | 7 lines of WIT interface, arbitrary Python | Full CPython + stdlib, at 17.6MB and (normally) multi-second cold start |
+| Pyodide | Plain Python, no interface code at all | Full CPython + stdlib, at 11.9MB core + 845ms cold start |
+
+The custom-runtime leg's 78 lines cover exactly one operation. A real language runtime
+built this way needs new hand-written code — on both the WASM side and the JS-import
+side — for every additional capability (arrays, maps, options, results, ...), which is
+exactly the shape of `mvl-playground`'s actual ~60-function runtime object. That
+ongoing, per-feature cost is the real price of the size/speed win in Finding 1,
+not a one-time cost paid once and then forgotten.
+
+### 4. A shared, pre-existing bug found and fixed along the way
+
+Gathering componentize-py's cold start honestly required actually trying it, not
+assuming it would work — and `../001_hello_world/lib/bench.sh`'s `cold_start_ms`
+(shared by every experiment in this repo, including 001, 002, 003, and this one) had
+**no success/failure signal at all**. If the polled server never came up, the
+function fell through and printed the *entire timeout budget* as if it were a real
+cold-start measurement — silently fabricating a number rather than reporting failure.
+First encountered exactly this way: componentize-py's `wasmtime serve` died
+instantly, but this experiment's own first attempt still reported a plausible-looking
+`12666ms` "cold start" for it, because the helper couldn't tell success from timeout.
+
+Fixed in `lib/bench.sh` (shared, so this benefits experiments 001-003 too, should any
+of their legs ever hit the same failure mode): the function now returns non-zero and
+prints nothing to stdout when the timeout elapses without a successful response,
+instead of silently reporting the timeout as a measurement. All three other
+experiments' `benchmark.sh` scripts already use `set -euo pipefail`, so this is the
+behavior they were already asking for — a failed cold-start probe will now stop the
+script with a clear message instead of continuing with a fabricated number.
+
+**Caught the same mistake a second time, one function away, before publishing.**
+This experiment's own Pyodide-leg measurement initially guarded
+`require_port_free 5002 ... || true` — swallowing exactly the kind of failure the
+fix above exists to surface. With a stray process still bound to port 5002 from
+earlier manual testing, that `|| true` let the script continue anyway: `run.sh`'s
+own server failed to bind, but `curl` happily talked to the *stray* process
+instead, producing a fabricated `37ms` "cold start" for a process that never
+cold-started at all — the same failure shape, one guard away from the fix just
+described. Removed the `|| true`; the script now stops with a clear message if the
+port isn't free, rather than measuring whatever happens to already be listening.
+
+## Usage
+
+```bash
+./benchmark.sh    # builds and measures all three legs; ~15-20s total
+                  # (componentize-py's cold-start step is expected to report
+                  # N/A in an environment with this wasmtime/componentize-py
+                  # version combination -- see Finding 2)
+```
+
+## Structure
+
+```
+007_custom_runtime_vs_interpreter/
+├── README.md
+├── benchmark.sh                   # builds + measures all three legs directly
+└── custom_runtime/
+    ├── rust/
+    │   ├── Cargo.toml              # wasm32-unknown-unknown, no WASI
+    │   └── src/lib.rs              # the whole "language": one string-concat op
+    └── harness/
+        ├── runtime.js              # the hand-written JS runtime shim (~37 lines)
+        └── measure.mjs             # Node: instantiate + one call, timed
+    # rust/target/ is gitignored (build.sh-equivalent output)
+
+# componentize-py and Pyodide legs are NOT duplicated here -- benchmark.sh
+# builds/runs them in place inside ../003_wasm_compile/python-raw/ and
+# ../001_hello_world/leg2a_pyodide_node/ respectively.
+```

--- a/experiments/007_custom_runtime_vs_interpreter/benchmark.sh
+++ b/experiments/007_custom_runtime_vs_interpreter/benchmark.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# benchmark.sh — gathers artifact size, cold start, and a build-complexity
+# metric for all three legs, directly rather than assuming experiment
+# 001/003's own result tables are populated (they were blank as of this
+# experiment being filed).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ../001_hello_world/lib/bench.sh
+
+EXPERIMENTS_ROOT="$(cd .. && pwd)"
+
+echo "=========================================="
+echo "Leg 1: custom_runtime"
+echo "=========================================="
+(cd custom_runtime/rust && cargo build --target wasm32-unknown-unknown --release >/dev/null)
+CUSTOM_WASM="custom_runtime/rust/target/wasm32-unknown-unknown/release/custom_runtime_demo.wasm"
+CUSTOM_SIZE=$(human_size "$CUSTOM_WASM")
+CUSTOM_RESULT=$(cd custom_runtime/harness && node measure.mjs)
+CUSTOM_OK=$(echo "$CUSTOM_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['ok'])")
+CUSTOM_MS=$(echo "$CUSTOM_RESULT" | python3 -c "import json,sys; print(f\"{json.load(sys.stdin)['coldStartMs']:.2f}\")")
+ok "custom_runtime: artifact=$CUSTOM_SIZE cold_start=${CUSTOM_MS}ms ok=$CUSTOM_OK"
+CUSTOM_RUST_LINES=$(wc -l < custom_runtime/rust/src/lib.rs | tr -d ' ')
+CUSTOM_JS_LINES=$(wc -l < custom_runtime/harness/runtime.js | tr -d ' ')
+
+echo
+echo "=========================================="
+echo "Leg 2: componentize-py (reusing experiment 003's python-raw)"
+echo "=========================================="
+CPY_DIR="$EXPERIMENTS_ROOT/003_wasm_compile"
+if [ ! -d "$CPY_DIR/.venv" ]; then
+  info "Setting up venv + componentize-py..."
+  python3 -m venv "$CPY_DIR/.venv"
+  "$CPY_DIR/.venv/bin/pip" install --quiet -r "$CPY_DIR/requirements.txt"
+fi
+(cd "$CPY_DIR/python-raw" && ../.venv/bin/componentize-py -d wit -w proxy componentize app -o hello-py-raw.wasm >/dev/null)
+CPY_WASM="$CPY_DIR/python-raw/hello-py-raw.wasm"
+CPY_SIZE=$(human_size "$CPY_WASM")
+ok "componentize-py: artifact=$CPY_SIZE (built successfully)"
+
+CPY_COLD_START="N/A (see README)"
+if command -v wasmtime &>/dev/null; then
+  info "Attempting cold-start via wasmtime serve (known to fail in this environment — see README)..."
+  wasmtime serve "$CPY_WASM" --addr 127.0.0.1:5032 >/tmp/exp007_cpy.log 2>&1 &
+  CPY_PID=$!
+  # cold_start_ms itself (fixed in this same experiment — see README "Finding")
+  # now fails loudly rather than silently reporting a timeout as a real
+  # number, so `|| true` here means "continue the benchmark," not "hide
+  # the failure" — the failure is still reported via CPY_COLD_START.
+  if CS=$(cold_start_ms 5032 / 10 2>&1); then
+    CPY_COLD_START="${CS}ms"
+    ok "componentize-py: cold_start=$CPY_COLD_START"
+  else
+    info "componentize-py cold start could not be measured — see /tmp/exp007_cpy.log"
+    tail -5 /tmp/exp007_cpy.log || true
+  fi
+  kill_and_wait "$CPY_PID" 2>/dev/null || true
+fi
+CPY_WIT_LINES=$(wc -l < "$CPY_DIR/python-raw/wit/proxy.wit" | tr -d ' ')
+
+echo
+echo "=========================================="
+echo "Leg 3: Pyodide (reusing experiment 001's leg2a_pyodide_node)"
+echo "=========================================="
+PYO_DIR="$EXPERIMENTS_ROOT/001_hello_world/leg2a_pyodide_node"
+# No `|| true` here: if port 5002 is already held (e.g. a stray process from
+# a previous run), continuing anyway means run.sh's own server fails to bind
+# while curl happily talks to whatever *else* is on that port -- a fabricated
+# "cold start" measurement of a process that never actually cold-started.
+# Same failure shape as the cold_start_ms bug this experiment found and
+# fixed (Finding 4); worth not repeating it one function away.
+require_port_free 5002 "pyodide leg"
+(cd "$PYO_DIR" && ./run.sh) >/tmp/exp007_pyodide.log 2>&1 &
+PYO_PID=$!
+PYO_CS=$(cold_start_ms 5002 / 15)
+kill_and_wait "$PYO_PID"
+pkill -f "leg2a_pyodide_node/harness.js" 2>/dev/null || true
+ok "Pyodide: cold_start=${PYO_CS}ms"
+PYO_CORE_SIZE=$(human_size "$PYO_DIR/node_modules/pyodide/pyodide.asm.wasm" "$PYO_DIR/node_modules/pyodide/python_stdlib.zip")
+
+echo
+echo "## Results — experiment 007"
+echo
+echo "| Leg | Artifact size | Cold start | Hand-written runtime code | External toolchain |"
+echo "|---|---|---|---|---|"
+echo "| custom_runtime | $CUSTOM_SIZE | ${CUSTOM_MS}ms | ${CUSTOM_RUST_LINES} (rust) + ${CUSTOM_JS_LINES} (js) = $((CUSTOM_RUST_LINES + CUSTOM_JS_LINES)) lines | rustc + wasm32-unknown-unknown (stock) |"
+echo "| componentize-py | $CPY_SIZE | $CPY_COLD_START | 0 lines (embeds CPython) | componentize-py + ${CPY_WIT_LINES}-line hand-authored WIT (+ ~3000 lines vendored WASI world defs, not hand-authored) |"
+echo "| Pyodide | $PYO_CORE_SIZE (core .wasm + stdlib.zip) | ${PYO_CS}ms | 0 lines (embeds CPython) | npm \`pyodide\` package |"

--- a/experiments/007_custom_runtime_vs_interpreter/custom_runtime/harness/measure.mjs
+++ b/experiments/007_custom_runtime_vs_interpreter/custom_runtime/harness/measure.mjs
@@ -1,0 +1,36 @@
+// measure.mjs — cold start (instantiate + one call) for the custom-runtime leg.
+// No browser needed: nothing here is WASI or DOM-dependent, a plain Node
+// process instantiating the module is a fair "cold start" measurement,
+// analogous in spirit to the other legs' process-launch-to-first-response.
+import { readFileSync } from "node:fs";
+import { createRuntime } from "./runtime.js";
+
+const bytes = readFileSync(new URL("../rust/target/wasm32-unknown-unknown/release/custom_runtime_demo.wasm", import.meta.url));
+
+const t0 = performance.now();
+let memory;
+const runtime = createRuntime(() => memory);
+const { instance } = await WebAssembly.instantiate(bytes, { runtime: runtime.imports });
+memory = instance.exports.memory;
+
+const name = "World";
+const nameBytes = new TextEncoder().encode(name);
+const inputPtr = instance.exports.input_ptr();
+new Uint8Array(memory.buffer, inputPtr, nameBytes.length).set(nameBytes);
+
+const outLen = instance.exports.greet(nameBytes.length);
+const outputPtr = instance.exports.output_ptr();
+const result = new TextDecoder().decode(new Uint8Array(memory.buffer, outputPtr, outLen));
+const coldStartMs = performance.now() - t0;
+
+if (result !== "Hello, World") {
+  console.error(JSON.stringify({ ok: false, result }));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  result,
+  coldStartMs,
+  handleCount: runtime.handleCount(),
+}));

--- a/experiments/007_custom_runtime_vs_interpreter/custom_runtime/harness/runtime.js
+++ b/experiments/007_custom_runtime_vs_interpreter/custom_runtime/harness/runtime.js
@@ -1,0 +1,37 @@
+// runtime.js — the entire hand-written "language runtime" this leg tests
+// the cost of. Mirrors mvl-lang/mvl-playground's actual pattern in
+// web/src/runtime/mvl-runtime.ts: a Map-based handle table, string bytes
+// read directly out of the WASM instance's own linear memory.
+export function createRuntime(getMemory) {
+  const strings = new Map();
+  let nextHandle = 1;
+  const decoder = new TextDecoder("utf-8");
+  const encoder = new TextEncoder();
+
+  function readString(ptr, len) {
+    const bytes = new Uint8Array(getMemory().buffer, ptr, len);
+    return decoder.decode(bytes);
+  }
+
+  return {
+    imports: {
+      string_new: (ptr, len) => {
+        const h = nextHandle++;
+        strings.set(h, readString(ptr, len));
+        return h;
+      },
+      string_concat: (h1, h2) => {
+        const h = nextHandle++;
+        strings.set(h, (strings.get(h1) ?? "") + (strings.get(h2) ?? ""));
+        return h;
+      },
+      string_write: (handle, destPtr) => {
+        const s = strings.get(handle) ?? "";
+        const bytes = encoder.encode(s);
+        new Uint8Array(getMemory().buffer, destPtr, bytes.length).set(bytes);
+        return bytes.length;
+      },
+    },
+    handleCount: () => strings.size,
+  };
+}

--- a/experiments/007_custom_runtime_vs_interpreter/custom_runtime/rust/Cargo.toml
+++ b/experiments/007_custom_runtime_vs_interpreter/custom_runtime/rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "custom_runtime_demo"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = "z"
+lto = true
+strip = true
+panic = "abort"

--- a/experiments/007_custom_runtime_vs_interpreter/custom_runtime/rust/src/lib.rs
+++ b/experiments/007_custom_runtime_vs_interpreter/custom_runtime/rust/src/lib.rs
@@ -1,0 +1,41 @@
+// The entire "language": one operation (string concatenation), backed by
+// a hand-written JS import object — mirroring mvl-lang/mvl-playground's
+// actual pattern (handle-based string ops via a custom "runtime" import
+// namespace), at the smallest scale that still exercises the same shape.
+// No WASI, no interpreter, no standard library runtime — wasm32-unknown-
+// unknown, three imported functions, two static scratch buffers.
+
+#[link(wasm_import_module = "runtime")]
+extern "C" {
+    fn string_new(ptr: i32, len: i32) -> i32;
+    fn string_concat(h1: i32, h2: i32) -> i32;
+    fn string_write(handle: i32, dest_ptr: i32) -> i32;
+}
+
+static mut INPUT_SCRATCH: [u8; 256] = [0; 256];
+static mut OUTPUT_SCRATCH: [u8; 256] = [0; 256];
+const PREFIX: &str = "Hello, ";
+
+/// Where the host should write the input name's bytes before calling greet().
+#[no_mangle]
+pub extern "C" fn input_ptr() -> i32 {
+    core::ptr::addr_of!(INPUT_SCRATCH) as i32
+}
+
+/// Where the host should read the result bytes after greet() returns.
+#[no_mangle]
+pub extern "C" fn output_ptr() -> i32 {
+    core::ptr::addr_of!(OUTPUT_SCRATCH) as i32
+}
+
+/// name_len bytes have already been written at input_ptr(). Returns the
+/// result length (bytes available at output_ptr()).
+#[no_mangle]
+pub extern "C" fn greet(name_len: i32) -> i32 {
+    unsafe {
+        let prefix_handle = string_new(PREFIX.as_ptr() as i32, PREFIX.len() as i32);
+        let name_handle = string_new(core::ptr::addr_of!(INPUT_SCRATCH) as i32, name_len);
+        let result_handle = string_concat(prefix_handle, name_handle);
+        string_write(result_handle, core::ptr::addr_of!(OUTPUT_SCRATCH) as i32)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #29. `mvl-lang/mvl-playground` doesn't embed an interpreter into WASM at all — it ships a hand-written ~60-function JS runtime object as a custom import namespace. Compares that strategy against componentize-py (experiment 003) and Pyodide (experiments 001/002) on artifact size, cold start, and build complexity — gathered directly, not assumed from those experiments' still-blank result tables.

## Results

| Leg | Artifact | Cold start | Hand-written code |
|---|---|---|---|
| custom_runtime | 302 bytes | 0.3-1.4ms | 78 lines |
| componentize-py | 17.6MB | N/A (see below) | 0 (embeds CPython) |
| Pyodide | 11.9MB | ~850-950ms | 0 (embeds CPython) |

**Not an apples-to-apples functional comparison** — componentize-py/Pyodide serve a full HTTP JSON handler; `custom_runtime` does one string-concat op, because that's the actual shape of the playground's own pattern. Stated explicitly in the README rather than implied as equivalent.

## Two real, pre-existing gaps in experiment 003, reported not duplicated

- `wasmtime` 43.0.1 rejects the componentize-py-generated component: `wasi:cli/environment@0.2.4 ... implementation was not found` — a WASI Preview2 world-version skew, not a bug in the artifact (which builds fine, 17.6MB, confirmed real).
- `python-spin` (tried as a fallback runtime path) has no `wit/` directory tracked at all — `spin build` fails before even trying.

Both out of scope for this ticket — reported for whoever next works on #003.

## A shared bug found and fixed along the way

`../001_hello_world/lib/bench.sh`'s `cold_start_ms` (used by every experiment in this repo) had **no success/failure signal** — a server that never came up silently reported the full timeout budget as if it were a real measurement. First caught exactly this way: componentize-py's instant crash still initially produced a fake `12666ms` "cold start." Fixed to fail loudly instead.

**Caught the identical mistake a second time, one function away, before publishing**: this experiment's own Pyodide measurement had `require_port_free 5002 ... || true`, silently swallowing exactly the failure the fix above exists to surface. Removed before it shipped.

## Changes

### Added
- `experiments/007_custom_runtime_vs_interpreter/` — new custom-runtime leg + benchmark harness for all three legs

### Fixed
- `experiments/001_hello_world/lib/bench.sh` — `cold_start_ms` now fails loudly on timeout instead of fabricating a number
- Top-level `README.md` experiment table to include #007

## Testing

- [x] `./benchmark.sh` builds and measures all three legs
- [x] Clean-room rebuild (fresh port, fresh `rust/target`) reproduces consistent numbers across three separate runs
- [x] Both experiment-003 gaps reproduced with real error messages, not asserted

## Related Issues

Closes #29.

---
🤖 *Generated with [Claude Code](https://claude.ai/code)*