### PR TITLE
feat: experiment 008 — standalone MVL-WASM example harness, found a new bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Reference: [AWS's Stealth Container Killer](https://aws.plainenglish.io/awss-ste
 | [005](experiments/005_stdout_capture_load/) | stdout_capture_load | done | stdout/stderr capture correctness + overhead at 10/1,000/100,000 lines |
 | [006](experiments/006_worker_kill_switch/) | worker_kill_switch | done | `Worker.terminate()` against a genuine infinite loop — is it actually instant? (No — ~2.1s) |
 | [007](experiments/007_custom_runtime_vs_interpreter/) | custom_runtime_vs_interpreter | done | Hand-written 78-line JS runtime shim vs. componentize-py vs. Pyodide — artifact size, cold start, build complexity |
+| [008](experiments/008_mvl_example_wasm_harness/) | mvl_example_wasm_harness | done | Standalone (non-browser) host for `mvl build --backend=wasm` output — found a new actor-routing crash in `actor_trading` (mvl-lang/mvl#2083) |
 
 ## Structure
 

--- a/experiments/008_mvl_example_wasm_harness/.gitignore
+++ b/experiments/008_mvl_example_wasm_harness/.gitignore
@@ -1,0 +1,3 @@
+# node_modules/, package-lock.json already covered by repo-root .gitignore.
+test-cases/*/*.wat
+test-cases/*/*.wasm

--- a/experiments/008_mvl_example_wasm_harness/README.md
+++ b/experiments/008_mvl_example_wasm_harness/README.md
@@ -1,0 +1,124 @@
+# Experiment 008 — Standalone MVL-WASM Example Harness
+
+A second, independent host for `mvl build --backend=wasm` output, outside a browser.
+Motivated directly by experiments 004-007: this repo spent a whole session
+understanding WASM execution mechanics (static-page delivery, stdout capture,
+`Worker.terminate()` timing, runtime strategy) using deliberately tiny test
+programs. This experiment applies that understanding to the actual question those
+experiments were building toward — **does the WASM backend hold up on real,
+non-trivial MVL programs**, not just hello-world-scale ones — and is built so the
+same approach could be folded into `mvl-lang/mvl-playground` later as an automated
+check, rather than the playground's 12 curated examples being the only proof the
+WASM backend works on anything.
+
+## The gap this closes
+
+`mvl-lang/mvl-playground` is currently the **only** thing anywhere that can execute
+`mvl build --backend=wasm` output. Confirmed directly, not assumed:
+
+- `mvl run` doesn't accept `--backend=wasm` at all (not in its own `--help`)
+- Bare `wasmtime run main.wasm` fails: `unknown import: runtime::memory has not been defined` — the compiled module expects a `runtime` import namespace (~60 hand-written functions for string/array/option/result/map operations) that is a **playground-specific convention**, not a standard WASI world. Nothing outside the playground's own JS implements it.
+
+So "does this MVL program actually run correctly under the WASM backend" has never
+been testable for anything outside the playground's 12 curated examples — which are,
+by construction, the *only* ones anyone has ever run this way.
+
+## What this harness is
+
+- **`harness/mvl-runtime.js`** — a byte-faithful port of `mvl-lang/mvl-playground`'s
+  `web/src/runtime/mvl-runtime.ts` (TS → plain JS, no logic changes — every function
+  ported 1:1). This tests the actual runtime the playground ships, not a
+  reimplementation of it. If `mvl-runtime.ts` changes upstream, this file needs the
+  same change, or it stops being a faithful test of what the playground actually
+  does.
+- **`harness/run-example.mjs`** — compiles an `.mvl` file (`mvl build --backend=wasm`),
+  converts WAT → WASM binary (`wasm-tools parse`, the CLI-equivalent of what the
+  playground's Rust backend does server-side via the `wat` crate), instantiates
+  against the ported runtime + `@bjorn3/browser_wasi_shim` (same shim experiments
+  004-007 used, works identically in plain Node — no browser needed for any of
+  this), and captures stdout/stderr.
+- **`run-tests.sh`** — for each `test-cases/<name>/`, runs it and diffs captured
+  output against `expected-stdout.txt` (captured from `mvl run main.mvl` — the
+  native/Rust-backend execution, ground truth for correct behavior).
+
+No browser, no Playwright, no headless Chromium anywhere in this experiment — a
+genuinely lighter-weight testing approach than the playground's own Worker-based
+execution, since none of what's being tested here (does the compiled module run
+correctly against the runtime convention) actually needs a browser context.
+
+## Test case: actor_trading
+
+Chosen deliberately as something with real complexity, not another hello-world:
+`mvl-lang/mvl/examples/actor_trading` is an order-matching engine with real actors
+(`OrderBook`, `Matcher`), not the toy ping-pong of `actor_pingpong` (the only
+actor-based example currently curated into the playground).
+
+**Result: FAIL, precisely located.**
+
+```
+=== actor_trading ===
+  FAIL — output diverges from mvl run (native backend)
+  --- diff (expected vs actual) ---
+  4,19d3
+  < 
+  < --- scenario 2: resting bid crossed by aggressive ask ---
+  < OrderBook: ask 0 price=100 qty=10
+  ... [rest of scenarios 2-3 never printed]
+  --- runtime error ---
+      at order_book_submit (wasm://.../wasm-function[66]:0xbbe)
+      at order_book_dispatch (wasm://.../wasm-function[67]:0xc46)
+      at __mvl_actor_route (wasm://.../wasm-function[75]:0xf6b)
+      at __mvl_actor_pump (wasm://.../wasm-function[76]:0xfb1)
+      at _start (wasm://.../wasm-function[79]:0x1091)
+```
+
+The module compiles cleanly (no warnings, all 60 `runtime` imports satisfied) and
+runs correctly right up until the first real actor-to-actor message dispatch, then
+traps with `memory access out of bounds` inside the compiled module's own code —
+not in a call to the JS runtime.
+
+**Ruled out before filing, not assumed:**
+- Not a missing import — the crash is inside `order_book_submit`, not at a call boundary into JS.
+- Not a memory-capacity issue — reproduces identically at `initial: 1` (64KB, the playground's actual default) and `initial: 64` (4MB). The module never emits `memory.grow` (`grep -c memory.grow main.wat` = 0), so more memory can't help; something computes or dereferences a wrong address.
+- Not one of the three already-tracked WASM gaps (mvl#2054 extension methods, #2055 `std.env.exit`, #2056 `std.log`) — none involve actor message routing.
+
+**Filed as [mvl-lang/mvl#2083](https://github.com/mvl-lang/mvl/issues/2083).** New bug, not a duplicate — checked all three related issues before filing.
+
+## Usage
+
+```bash
+cd harness && npm install    # once
+cd ..
+./run-tests.sh                # runs every test-cases/*/, reports PASS/FAIL with diffs
+```
+
+To try a different example: copy its `.mvl` files into `test-cases/<name>/`, capture
+its correct output via `mvl run main.mvl` into `test-cases/<name>/expected-stdout.txt`
+(strip the compiler's own build-status lines from the top), and re-run.
+
+## Structure
+
+```
+008_mvl_example_wasm_harness/
+├── README.md
+├── run-tests.sh
+├── harness/
+│   ├── mvl-runtime.js       # ported from mvl-playground's mvl-runtime.ts
+│   ├── run-example.mjs      # compile -> WAT->WASM -> instantiate -> capture
+│   └── package.json         # @bjorn3/browser_wasi_shim
+└── test-cases/
+    └── actor_trading/
+        ├── main.mvl          # copied from mvl-lang/mvl/examples/actor_trading
+        ├── types.mvl
+        └── expected-stdout.txt  # captured via `mvl run main.mvl`
+    # main.wat / main.wasm are run-example.mjs output, gitignored
+```
+
+## What could move into mvl-playground later
+
+The `runtime` namespace convention and the WAT→WASM→instantiate pipeline are
+identical to what the playground already does — this harness's real value if
+adopted there is as a **CI check independent of the browser**: run every example a
+future curator considers adding through `run-tests.sh` before it's wired into
+`sync-examples.sh`, so a broken example is caught by a fast Node script instead of a
+silently blank Runtime tab in a real user's browser.

--- a/experiments/008_mvl_example_wasm_harness/harness/mvl-runtime.js
+++ b/experiments/008_mvl_example_wasm_harness/harness/mvl-runtime.js
@@ -1,0 +1,339 @@
+// mvl-runtime.js — standalone JS implementation of the MVL WASM runtime.
+//
+// Ported verbatim (mechanical TS -> JS translation, no logic changes) from
+// mvl-lang/mvl-playground's web/src/runtime/mvl-runtime.ts, so this harness
+// tests the actual runtime the playground ships, not a reimplementation of
+// it. If mvl-runtime.ts changes, port the change here too — divergence
+// between this file and the playground's is exactly the kind of drift this
+// whole session has been about catching.
+//
+// The MVL WASM backend (mvl build --backend=wasm) emits imports under a
+// "runtime" namespace: a shared WebAssembly.Memory plus ~60 functions for
+// string/array/option/result/map operations. The WASM module uses a bump
+// allocator within this memory, writes string bytes, and passes (ptr, len)
+// pairs to runtime functions. Functions that "create" values (string_new,
+// array_new, option_some, etc.) return opaque i32 handles into
+// runtime-managed tables.
+//
+// Source: mvl-lang/mvl-playground web/src/runtime/mvl-runtime.ts,
+// mvl-lang/mvl release v1.7.2 runtime.
+
+let nextHandle = 1;
+
+function newHandle() {
+  return nextHandle++;
+}
+
+export function createMvlRuntime() {
+  const memory = new WebAssembly.Memory({ initial: 1, maximum: 256 });
+  const u8 = () => new Uint8Array(memory.buffer);
+
+  const strings = new Map();
+  const arrays = new Map();
+  const options = new Map();
+  const results = new Map();
+  const maps = new Map();
+  const structs = new Map();
+
+  const decoder = new TextDecoder("utf-8");
+
+  function readString(ptr, len) {
+    if (len <= 0) return "";
+    return decoder.decode(u8().subarray(ptr, ptr + len));
+  }
+
+  function storeString(s) {
+    const h = newHandle();
+    strings.set(h, s);
+    return h;
+  }
+
+  function storeArray(a) {
+    const h = newHandle();
+    arrays.set(h, a);
+    return h;
+  }
+
+  function storeOption(tag, value) {
+    const h = newHandle();
+    options.set(h, { tag, value });
+    return h;
+  }
+
+  function storeResult(tag, value, error) {
+    const h = newHandle();
+    results.set(h, { tag, value, error });
+    return h;
+  }
+
+  function storeMap(m) {
+    const h = newHandle();
+    maps.set(h, m);
+    return h;
+  }
+
+  const runtime = {
+    memory,
+
+    // ── String functions (ptr, len) -> handle or scalar ──────────────
+
+    _mvl_string_eq: (p1, l1, p2, l2) =>
+      readString(p1, l1) === readString(p2, l2) ? 1 : 0,
+
+    _mvl_string_len: (ptr, len) => BigInt([...readString(ptr, len)].length),
+
+    _mvl_string_is_empty: (ptr, len) => (readString(ptr, len).length === 0 ? 1 : 0),
+
+    _mvl_string_contains: (p1, l1, p2, l2) =>
+      readString(p1, l1).includes(readString(p2, l2)) ? 1 : 0,
+
+    _mvl_string_starts_with: (p1, l1, p2, l2) =>
+      readString(p1, l1).startsWith(readString(p2, l2)) ? 1 : 0,
+
+    _mvl_string_ends_with: (p1, l1, p2, l2) =>
+      readString(p1, l1).endsWith(readString(p2, l2)) ? 1 : 0,
+
+    _mvl_string_find: (p1, l1, p2, l2) => {
+      const idx = readString(p1, l1).indexOf(readString(p2, l2));
+      return BigInt(idx);
+    },
+
+    _mvl_string_new: (ptr, len) => storeString(readString(ptr, len)),
+
+    _mvl_string_clone: (h) => {
+      const s = strings.get(h);
+      return s !== undefined ? storeString(s) : storeString("");
+    },
+
+    _mvl_string_drop: (h) => {
+      strings.delete(h);
+    },
+
+    _mvl_string_concat: (p1, l1, p2, l2) =>
+      storeString(readString(p1, l1) + readString(p2, l2)),
+
+    _mvl_string_substring: (ptr, len, start, end) => {
+      const s = readString(ptr, len);
+      const chars = [...s];
+      const lo = Math.max(0, Number(start));
+      const hi = Math.max(0, Number(end));
+      return storeString(chars.slice(lo, Math.min(hi, chars.length)).join(""));
+    },
+
+    _mvl_string_to_upper: (ptr, len) => storeString(readString(ptr, len).toUpperCase()),
+
+    _mvl_string_to_lower: (ptr, len) => storeString(readString(ptr, len).toLowerCase()),
+
+    _mvl_string_trim: (ptr, len) => storeString(readString(ptr, len).trim()),
+
+    _mvl_string_replace: (sp, sl, fp, fl, tp, tl) =>
+      storeString(readString(sp, sl).split(readString(fp, fl)).join(readString(tp, tl))),
+
+    _mvl_string_parse_int: (ptr, len) => {
+      const s = readString(ptr, len).trim();
+      const n = Number(s);
+      if (s !== "" && !isNaN(n) && Number.isInteger(n)) {
+        return storeResult(1, BigInt(n));
+      }
+      return storeResult(0, 0n, `invalid integer: "${s}"`);
+    },
+
+    // ── Array functions (handle-based) ────────────────────────────────
+
+    _mvl_array_new: (_elemType, _capacity) => storeArray([]),
+
+    _mvl_array_len: (h) => BigInt(arrays.get(h)?.length ?? 0),
+
+    _mvl_array_is_empty: (h) => ((arrays.get(h)?.length ?? 1) === 0 ? 1 : 0),
+
+    _mvl_array_push: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_push_i32: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_push_i64: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_push_f64: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_get: (h, idx) => {
+      const arr = arrays.get(h);
+      if (!arr) return 0;
+      const i = Number(idx);
+      return i >= 0 && i < arr.length ? arr[i] : 0;
+    },
+
+    _mvl_array_clone: (h) => {
+      const arr = arrays.get(h);
+      return storeArray(arr ? [...arr] : []);
+    },
+
+    _mvl_array_drop: (h) => {
+      arrays.delete(h);
+    },
+
+    _mvl_string_ptr_array_drop: (h) => {
+      arrays.delete(h);
+    },
+
+    _mvl_string_ptr_array_dedup: (h) => {
+      const arr = arrays.get(h);
+      if (arr) {
+        const seen = new Set();
+        const deduped = arr.filter((v) => {
+          if (seen.has(v)) return false;
+          seen.add(v);
+          return true;
+        });
+        arrays.set(h, deduped);
+      }
+    },
+
+    _mvl_array_dedup_i64: (h) => {
+      const arr = arrays.get(h);
+      if (arr) {
+        const seen = new Set();
+        arrays.set(h, arr.filter((v) => (seen.has(v) ? false : (seen.add(v), true))));
+      }
+    },
+
+    _mvl_array_dedup_i32: (h) => {
+      const arr = arrays.get(h);
+      if (arr) {
+        const seen = new Set();
+        arrays.set(h, arr.filter((v) => (seen.has(v) ? false : (seen.add(v), true))));
+      }
+    },
+
+    _mvl_array_contains_i64: (h, val) => {
+      const arr = arrays.get(h);
+      return arr && arr.includes(val) ? 1 : 0;
+    },
+
+    _mvl_array_contains_i32: (h, val) => {
+      const arr = arrays.get(h);
+      return arr && arr.includes(val) ? 1 : 0;
+    },
+
+    _mvl_array_insert_i64: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_insert_i32: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    // ── Option functions ─────────────────────────────────────────────
+
+    _mvl_option_some_i64: (val) => storeOption(1, val),
+    _mvl_option_some_i32: (val) => storeOption(1, val),
+    _mvl_option_none: () => storeOption(0, 0),
+
+    _mvl_option_tag: (h) => options.get(h)?.tag ?? 0,
+
+    _mvl_option_value_i64: (h) => {
+      const opt = options.get(h);
+      return opt ? BigInt(opt.value) : 0n;
+    },
+
+    _mvl_option_value_i32: (h) => {
+      const opt = options.get(h);
+      return opt ? Number(opt.value) : 0;
+    },
+
+    _mvl_option_drop: (h) => {
+      options.delete(h);
+    },
+
+    _mvl_array_get_option_i64: (h, idx) => {
+      const arr = arrays.get(h);
+      if (!arr) return storeOption(0, 0);
+      const i = Number(idx);
+      if (i < 0 || i >= arr.length) return storeOption(0, 0);
+      return storeOption(1, BigInt(arr[i]));
+    },
+
+    _mvl_array_get_option_i32: (h, idx) => {
+      const arr = arrays.get(h);
+      if (!arr) return storeOption(0, 0);
+      const i = Number(idx);
+      if (i < 0 || i >= arr.length) return storeOption(0, 0);
+      return storeOption(1, arr[i]);
+    },
+
+    // ── Result functions ──────────────────────────────────────────────
+
+    _mvl_result_ok_i64: (val) => storeResult(1, val),
+    _mvl_result_ok_i32: (val) => storeResult(1, val),
+    _mvl_result_err_str: (ptr, len) => storeResult(0, 0, readString(ptr, len)),
+
+    _mvl_result_tag: (h) => results.get(h)?.tag ?? 0,
+
+    _mvl_result_value_i64: (h) => {
+      const r = results.get(h);
+      return r ? BigInt(r.value) : 0n;
+    },
+
+    _mvl_result_value_i32: (h) => {
+      const r = results.get(h);
+      return r ? Number(r.value) : 0;
+    },
+
+    _mvl_result_drop: (h) => {
+      results.delete(h);
+    },
+
+    // ── Map functions ─────────────────────────────────────────────────
+
+    _mvl_map_new_si64: () => storeMap(new Map()),
+
+    _mvl_map_len: (h) => BigInt(maps.get(h)?.size ?? 0),
+
+    _mvl_map_insert_si64: (h, kp, kl, val) => {
+      maps.get(h)?.set(readString(kp, kl), val);
+    },
+
+    _mvl_map_get_si64: (h, kp, kl) => {
+      const m = maps.get(h);
+      if (!m) return storeOption(0, 0);
+      const val = m.get(readString(kp, kl));
+      if (val === undefined) return storeOption(0, 0);
+      return storeOption(1, BigInt(val));
+    },
+
+    _mvl_map_contains_key_si64: (h, kp, kl) =>
+      maps.get(h)?.has(readString(kp, kl)) ? 1 : 0,
+
+    _mvl_map_drop_si64: (h) => {
+      maps.delete(h);
+    },
+
+    // ── Struct ─────────────────────────────────────────────────────────
+
+    _mvl_struct_alloc: (size) => {
+      const h = newHandle();
+      structs.set(h, new Uint8Array(size));
+      return h;
+    },
+
+    // ── Audit (no-op — this harness doesn't persist an audit trail) ───
+
+    _mvl_audit_emit_relabel: (
+      _tagPtr, _tagLen,
+      _fromPtr, _fromLen,
+      _toPtr, _toLen,
+      _filePtr, _fileLen,
+      _line, _col,
+    ) => {
+      // No-op, matching mvl-playground's own runtime.
+    },
+  };
+
+  return { memory, runtime };
+}

--- a/experiments/008_mvl_example_wasm_harness/harness/package.json
+++ b/experiments/008_mvl_example_wasm_harness/harness/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mvl-wasm-example-harness",
+  "version": "1.0.0",
+  "description": "Standalone runner for mvl build --backend=wasm output, outside a browser",
+  "type": "module",
+  "scripts": {
+    "run": "node run-example.mjs"
+  },
+  "dependencies": {
+    "@bjorn3/browser_wasi_shim": "0.4.2"
+  }
+}

--- a/experiments/008_mvl_example_wasm_harness/harness/run-example.mjs
+++ b/experiments/008_mvl_example_wasm_harness/harness/run-example.mjs
@@ -1,0 +1,99 @@
+// run-example.mjs — compile an MVL source file to WASM, execute it against
+// this repo's ported mvl-runtime.js + WASI shim, and capture stdout/stderr.
+//
+// This is the actual gap this experiment exists to close: mvl-playground is
+// currently the ONLY host anywhere that can execute `mvl build --backend=wasm`
+// output. `mvl run` doesn't accept --backend=wasm; bare `wasmtime run` fails
+// with `unknown import: runtime::memory has not been defined`, because the
+// runtime namespace is a playground-specific convention, not a standard WASI
+// world. This script is a second, independent host implementing that same
+// convention, so "does this MVL program actually run under the WASM backend"
+// becomes testable outside a browser.
+//
+// Usage: node run-example.mjs <path/to/main.mvl>
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { WASI, File, OpenFile, ConsoleStdout } from "@bjorn3/browser_wasi_shim";
+import { createMvlRuntime } from "./mvl-runtime.js";
+
+const mvlFile = process.argv[2];
+if (!mvlFile) {
+  console.error("Usage: node run-example.mjs <path/to/main.mvl>");
+  process.exit(2);
+}
+
+const dir = dirname(mvlFile);
+const entry = basename(mvlFile);
+const watPath = join(dir, entry.replace(/\.mvl$/, ".wat"));
+const wasmPath = join(dir, entry.replace(/\.mvl$/, ".wasm"));
+
+// 1. Compile: mvl build --backend=wasm (produces WAT text, not a binary).
+// "WAT written to: ..." etc. are the compiler's own build-status messages,
+// not the program's output — piped and re-emitted on *this process's
+// stderr*, not stdout, so a caller capturing this script's stdout gets
+// exactly what the compiled program printed, nothing else. Still visible
+// (not discarded), so a compile failure is still diagnosable.
+const buildOutput = execFileSync("mvl", ["build", entry, "--backend=wasm"], {
+  cwd: dir,
+  stdio: ["inherit", "pipe", "inherit"],
+});
+process.stderr.write(buildOutput);
+
+if (!existsSync(watPath)) {
+  console.error(`expected ${watPath} after mvl build --backend=wasm, not found`);
+  process.exit(1);
+}
+
+// 2. WAT -> WASM binary. mvl-playground's own backend does this same
+// conversion server-side via the Rust `wat` crate (`wat::parse_bytes`);
+// `wasm-tools parse` is the CLI-equivalent conversion, not a different path.
+execFileSync("wasm-tools", ["parse", watPath, "-o", wasmPath]);
+const bytes = readFileSync(wasmPath);
+
+// 3. Instantiate against BOTH import namespaces the compiled module needs:
+// the custom "runtime" (the ~60-function convention) and WASI (for stdout/
+// stderr via println!/eprintln!). Both share one WebAssembly.Memory — the
+// module imports "runtime.memory" and re-exports it as "memory", which is
+// exactly what lets the WASI shim's own internal `instance.exports.memory`
+// access work against the same bytes the runtime functions read/write.
+const stdout = [];
+const stderr = [];
+const wasi = new WASI(
+  [entry],
+  [],
+  [
+    new OpenFile(new File([])),
+    ConsoleStdout.lineBuffered((msg) => stdout.push(msg)),
+    ConsoleStdout.lineBuffered((msg) => stderr.push(msg)),
+  ],
+);
+
+const { runtime } = createMvlRuntime();
+const { instance } = await WebAssembly.instantiate(bytes, {
+  runtime,
+  wasi_snapshot_preview1: wasi.wasiImport,
+});
+
+let exitCode = 0;
+let crashed = false;
+try {
+  exitCode = wasi.start(instance);
+} catch (err) {
+  // The full stack trace (not just err.message) is what actually locates a
+  // WASM-level trap: V8 includes the wasm call frames (function names,
+  // module offsets) leading to the fault, e.g.
+  //   at order_book_submit (wasm://.../wasm-function[66]:0xbbe)
+  //   at order_book_dispatch (...)
+  //   at __mvl_actor_route (...)
+  // A message-only catch would have reported just "memory access out of
+  // bounds" with no way to tell which compiled function it came from.
+  console.error(`--- runtime error ---\n${err && err.stack || err}`);
+  exitCode = 1;
+  crashed = true;
+}
+
+process.stdout.write(stdout.join("\n") + (stdout.length ? "\n" : ""));
+if (stderr.length) process.stderr.write(stderr.join("\n") + "\n");
+if (crashed) process.exitCode = exitCode;
+else process.exit(exitCode);

--- a/experiments/008_mvl_example_wasm_harness/run-tests.sh
+++ b/experiments/008_mvl_example_wasm_harness/run-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# run-tests.sh — for each test-cases/<name>/, run its main.mvl through the
+# WASM harness and compare stdout against expected-stdout.txt (captured
+# from `mvl run main.mvl` — the native/Rust-backend execution, treated as
+# ground truth for correct program behavior).
+#
+# A test case failing here is not a harness bug report — it's the harness
+# doing its job. Report the real result, including a known/tracked crash,
+# rather than skip or soften it.
+set -uo pipefail  # not -e: a failing test case is an expected, reported outcome, not a script error
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+FAIL=0
+for dir in test-cases/*/; do
+  name="$(basename "$dir")"
+  echo "=== $name ==="
+
+  actual="$(node harness/run-example.mjs "$dir/main.mvl" 2>/tmp/harness_stderr_$name.log)"
+  status=$?
+
+  if [ -f "$dir/expected-stdout.txt" ]; then
+    expected="$(cat "$dir/expected-stdout.txt")"
+    if [ "$actual" = "$expected" ]; then
+      echo "  PASS — output matches mvl run (native backend) exactly"
+    else
+      echo "  FAIL — output diverges from mvl run (native backend)"
+      echo "  --- diff (expected vs actual) ---"
+      diff <(echo "$expected") <(echo "$actual") | sed 's/^/  /'
+      if [ "$status" -ne 0 ]; then
+        echo "  --- runtime error (see full trace in /tmp/harness_stderr_$name.log) ---"
+        tail -5 "/tmp/harness_stderr_$name.log" | sed 's/^/  /'
+      fi
+      FAIL=1
+    fi
+  else
+    echo "  no expected-stdout.txt — printing captured output for inspection:"
+    echo "$actual" | sed 's/^/  /'
+  fi
+  echo
+done
+
+exit $FAIL

--- a/experiments/008_mvl_example_wasm_harness/test-cases/actor_trading/expected-stdout.txt
+++ b/experiments/008_mvl_example_wasm_harness/test-cases/actor_trading/expected-stdout.txt
@@ -1,0 +1,19 @@
+=== Verified Trading Engine ===
+
+--- scenario 1: resting ask crossed by aggressive bid ---
+
+--- scenario 2: resting bid crossed by aggressive ask ---
+OrderBook: ask 0 price=100 qty=10
+OrderBook: bid 1 price=102 qty=10
+Matcher: executing bid 1 vs ask 0 @ 100 x 10
+  FILL accepted  bid=1 ask=0 price=100 qty=10
+
+--- scenario 3: no cross (bid below ask) ---
+OrderBook: bid 0 price=99 qty=5
+OrderBook: ask 1 price=97 qty=5
+Matcher: executing bid 0 vs ask 1 @ 97 x 5
+  FILL accepted  bid=0 ask=1 price=97 qty=5
+
+Done.
+OrderBook: bid 0 price=95 qty=3
+OrderBook: ask 1 price=98 qty=3

--- a/experiments/008_mvl_example_wasm_harness/test-cases/actor_trading/main.mvl
+++ b/experiments/008_mvl_example_wasm_harness/test-cases/actor_trading/main.mvl
@@ -1,0 +1,313 @@
+// actor_trading/main.mvl — Verified trading engine with Phase 8 actors.
+//
+// Architecture:
+//
+//   OrderGateway  ──val order──►  OrderBook  ──tag matcher──►  Matcher
+//                                                                  │
+//                                                            iso fill
+//                                                                  │
+//                                                                  ▼
+//                                                           RiskChecker  ──► Console
+//
+// Demonstrates:
+//   1. Req 10 refinement types — Price and Quantity carry `where` predicates
+//      enforced at the call sites of new_bid/new_ask; the compiler rejects
+//      negative prices and zero quantities before any message is sent.
+//   2. val capability — Orders are immutable domain objects; val is the right
+//      capability for data that does not need exclusive ownership.
+//   3. iso capability — Fill is a single-use receipt produced by Matcher and
+//      consumed once by RiskChecker; iso enforces that exactly.
+//   4. tag capability — RiskChecker and Matcher hold tag references to each other;
+//      they can send messages but cannot read each other's internal state.
+//   5. implicit lifecycle — fn main() drains all actor mailboxes on exit (#1048).
+//
+// Usage:
+//   mvl run examples/actor_trading/main.mvl
+//   make run   (from examples/actor_trading/)
+
+use types::{Order, Fill, Side, OrderStatus}
+use std.ifc.{taint}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PRE-TRADE COMPLIANCE
+//
+// Two static guarantees that exercise the compiler's verification passes:
+//
+//   - Req 10 (Refinement types):  pre_trade_check carries `where` predicates
+//     on its scalar parameters.  Every call site must prove the predicates
+//     by construction; the 5-layer solver discharges literals in Layer 1.
+//
+//   - Req 11 (Information flow):  client_order_id arrives as Tainted[Int]
+//     (untrusted external input) and is only released to the matching engine
+//     after an explicit `relabel trust(...)` audit checkpoint.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Free function with refinement predicates — every call site is statically
+// proven by the layered refinement solver.  A call with a non-positive literal
+// is a compile error, not a runtime check.
+fn pre_trade_check(price: Int where price > 0, qty: Int where qty > 0) -> Bool {
+    price > 0 && qty > 0
+}
+
+// Sanitisation step at the trust boundary.  External client order IDs arrive
+// as `Tainted[Int]`; `relabel trust` is the auditable downgrade that records
+// the validation procedure used to clear the value for downstream use.
+fn admit_client_order_id(raw: Tainted[Int]) -> Int {
+    relabel trust(raw, "ORDER-ID-RANGE-CHECK")
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// RISK CHECKER
+//
+// Final gatekeeper: receives a Fill, validates the price invariant against
+// the original orders, and prints the execution report.
+// ═══════════════════════════════════════════════════════════════════════════
+
+actor RiskChecker {
+
+    accepted: Int
+    rejected: Int
+
+    // Behavior: validate and report a fill.
+    //
+    //   iso fill      — ownership of the Fill transferred from Matcher;
+    //                   RiskChecker is the unique consumer of this receipt
+    //   val bid_price — immutable bid limit, needed to check no-worse-than-limit
+    //   val ask_price — immutable ask limit
+    pub fn check(iso fill: Fill, val bid_price: Int, val ask_price: Int) ! Console {
+        // Property 1: no execution worse than limit
+        //   bid fills at price <= bid.price  AND  ask fills at price >= ask.price
+        let price_ok: Bool = fill.price <= bid_price && fill.price >= ask_price;
+        if price_ok {
+            self.accepted = self.accepted + 1
+            println(
+                "  FILL accepted  bid=".concat(fill.bid_order.to_string())
+                    .concat(" ask=").concat(fill.ask_order.to_string())
+                    .concat(" price=").concat(fill.price.to_string())
+                    .concat(" qty=").concat(fill.quantity.to_string())
+            )
+        } else {
+            self.rejected = self.rejected + 1
+            println(
+                "  FILL rejected  price=".concat(fill.price.to_string())
+                    .concat(" violates bid_limit=").concat(bid_price.to_string())
+                    .concat(" ask_limit=").concat(ask_price.to_string())
+            )
+        }
+    }
+
+    // Behavior: print summary when all fills have been processed.
+    pub fn summary() ! Console {
+        println(
+            "RiskChecker: ".concat(self.accepted.to_string())
+                .concat(" accepted, ").concat(self.rejected.to_string()).concat(" rejected")
+        )
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MATCHER
+//
+// Receives a bid/ask pair, computes execution price (ask price = passive
+// side's limit — satisfies both sides), and forwards the Fill to
+// RiskChecker for validation.
+// ═══════════════════════════════════════════════════════════════════════════
+
+actor Matcher {
+
+    risk: RiskChecker   // tag — can send messages, cannot read state
+
+    // Behavior: match a bid against an ask and produce a Fill.
+    //
+    //   val bid, val ask — immutable orders; both sides are read-only here,
+    //                      Matcher only needs to inspect price and quantity
+    //
+    // Execution price: ask.price (passive side sets the price —
+    // standard price-time priority).
+    // This satisfies:  ask.price <= exec_price <= bid.price
+    pub fn match_orders(val bid: Order, val ask: Order) ! Console + Send {
+        // Quantity conservation: fill at most what both sides can provide.
+        let exec_qty: Int = if bid.quantity < ask.quantity { bid.quantity } else { ask.quantity };
+        let exec_price: Int = ask.price;
+        let fill: Fill = Fill {
+            bid_order: bid.id,
+            ask_order: ask.id,
+            price:     exec_price,
+            quantity:  exec_qty,
+        };
+        println(
+            "Matcher: executing bid ".concat(bid.id.to_string())
+                .concat(" vs ask ").concat(ask.id.to_string())
+                .concat(" @ ").concat(exec_price.to_string())
+                .concat(" x ").concat(exec_qty.to_string())
+        )
+        // Forward fill with original limits so RiskChecker can verify the price invariant.
+        // iso: ownership of `fill` transfers here — Matcher no longer holds it.
+        self.risk.check(consume(fill), bid.price, ask.price)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ORDER BOOK
+//
+// Holds the resting bid and ask queues.  On each incoming order it checks
+// for a crossing (best ask <= best bid) and, if found, forwards both sides
+// to the Matcher for execution.
+//
+// Simplification: single-level book (one bid slot, one ask slot) so the
+// example stays readable.  A production book would use priority queues.
+// ═══════════════════════════════════════════════════════════════════════════
+
+actor OrderBook {
+
+    matcher:  Matcher           // tag — can dispatch to matcher
+    best_bid: Option[Order]     // resting bid (or None)
+    best_ask: Option[Order]     // resting ask (or None)
+
+    // Behavior: accept a new order and attempt a match if a crossing exists.
+    //
+    //   val order — immutable Order; OrderBook reads price/side and may store it
+    pub fn submit(val order: Order) ! Console + Send {
+        match order.side {
+            Side::Bid => {
+                println("OrderBook: bid ".concat(order.id.to_string())
+                    .concat(" price=").concat(order.price.to_string())
+                    .concat(" qty=").concat(order.quantity.to_string()));
+                match self.best_ask {
+                    None => {
+                        self.best_bid = Some(order)
+                    },
+                    Some(ask) => {
+                        if order.price >= ask.price {
+                            // Crossing: execute immediately; clear resting ask.
+                            self.best_ask = None
+                            self.matcher.match_orders(order, ask)
+                        } else {
+                            self.best_bid = Some(order)
+                        }
+                    },
+                }
+            },
+            Side::Ask => {
+                println("OrderBook: ask ".concat(order.id.to_string())
+                    .concat(" price=").concat(order.price.to_string())
+                    .concat(" qty=").concat(order.quantity.to_string()));
+                match self.best_bid {
+                    None => {
+                        self.best_ask = Some(order)
+                    },
+                    Some(bid) => {
+                        if bid.price >= order.price {
+                            // Crossing: execute immediately; clear resting bid.
+                            self.best_bid = None
+                            self.matcher.match_orders(bid, order)
+                        } else {
+                            self.best_ask = Some(order)
+                        }
+                    },
+                }
+            },
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ORDER GATEWAY
+//
+// Entry point for new orders.  This is where Req 10 enforcement happens:
+// `price: Price` and `quantity: Quantity` carry `where` predicates that the
+// compiler must prove satisfied at every call site.  A call like
+//   gw.new_bid(-50, 0)
+// is a compile error — the compiler rejects it before any message is sent.
+// ═══════════════════════════════════════════════════════════════════════════
+
+actor OrderGateway {
+
+    book:    OrderBook  // tag — dispatch target
+    next_id: Int        // sequential order ID counter
+
+    // Behavior: create and submit a new bid.
+    //
+    // Req 10 enforcement: the `where` predicates are checked statically by the
+    // solver at every call site.  A call like gw.new_bid(-50, 0) is a compile
+    // error — the compiler proves `-50 > 0` false before any message is sent.
+    pub fn new_bid(val price: Int where price > 0, val quantity: Int where quantity > 0) ! Console + Send {
+        let order: Order = Order {
+            id:       self.next_id,
+            side:     Side::Bid,
+            price:    price,
+            quantity: quantity,
+            status:   OrderStatus::Open,
+        };
+        self.next_id = self.next_id + 1
+        self.book.submit(order)
+    }
+
+    // Behavior: create and submit a new ask.
+    pub fn new_ask(val price: Int where price > 0, val quantity: Int where quantity > 0) ! Console + Send {
+        let order: Order = Order {
+            id:       self.next_id,
+            side:     Side::Ask,
+            price:    price,
+            quantity: quantity,
+            status:   OrderStatus::Open,
+        };
+        self.next_id = self.next_id + 1
+        self.book.submit(order)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ENTRY POINT
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn main() -> Unit ! Console + Actor {
+    println("=== Verified Trading Engine ===")
+
+    // ── Pre-trade compliance ───────────────────────────────────────────────
+    // Req 10: literals satisfy the refinement predicates by construction; the
+    // checker proves `100 > 0 && 10 > 0` at compile time (no runtime branch).
+    // Req 11: a `Tainted[Int]` value crosses the IFC boundary only via the
+    // explicit `relabel trust(...)` inside admit_client_order_id.
+    let _gate_ok: Bool = pre_trade_check(100, 10);
+    let _admitted: Int = admit_client_order_id(relabel taint(4242, "CLIENT-FIX-MSG"));
+
+    // Scenario 1: ask rests, bid crosses it.
+    // Ask #0: sell 10 lots @ 100  → rests (no bid)
+    // Bid #1: buy  10 lots @ 102  → crosses → executes @ 100 (ask price)
+    println("")
+    println("--- scenario 1: resting ask crossed by aggressive bid ---")
+    let risk1:    RiskChecker  = actor RiskChecker  { accepted: 0, rejected: 0 };
+    let matcher1: Matcher      = actor Matcher      { risk: risk1 };
+    let book1:    OrderBook    = actor OrderBook    { matcher: matcher1, best_bid: None, best_ask: None };
+    let gw1:      OrderGateway = actor OrderGateway { book: book1, next_id: 0 };
+    gw1.new_ask(100, 10)
+    gw1.new_bid(102, 10)
+
+    // Scenario 2: bid rests, ask crosses it.
+    // Bid #0: buy  5 lots @ 99  → rests (no ask)
+    // Ask #1: sell 5 lots @ 97  → crosses → executes @ 97 (ask price)
+    println("")
+    println("--- scenario 2: resting bid crossed by aggressive ask ---")
+    let risk2:    RiskChecker  = actor RiskChecker  { accepted: 0, rejected: 0 };
+    let matcher2: Matcher      = actor Matcher      { risk: risk2 };
+    let book2:    OrderBook    = actor OrderBook    { matcher: matcher2, best_bid: None, best_ask: None };
+    let gw2:      OrderGateway = actor OrderGateway { book: book2, next_id: 0 };
+    gw2.new_bid(99, 5)
+    gw2.new_ask(97, 5)
+
+    // Scenario 3: no cross — orders rest.
+    // Bid #0: buy  3 lots @ 95  → rests
+    // Ask #1: sell 3 lots @ 98  → rests (95 < 98, no crossing)
+    println("")
+    println("--- scenario 3: no cross (bid below ask) ---")
+    let risk3:    RiskChecker  = actor RiskChecker  { accepted: 0, rejected: 0 };
+    let matcher3: Matcher      = actor Matcher      { risk: risk3 };
+    let book3:    OrderBook    = actor OrderBook    { matcher: matcher3, best_bid: None, best_ask: None };
+    let gw3:      OrderGateway = actor OrderGateway { book: book3, next_id: 0 };
+    gw3.new_bid(95, 3)
+    gw3.new_ask(98, 3)
+
+    println("")
+    println("Done.")
+}

--- a/experiments/008_mvl_example_wasm_harness/test-cases/actor_trading/types.mvl
+++ b/experiments/008_mvl_example_wasm_harness/test-cases/actor_trading/types.mvl
@@ -1,0 +1,70 @@
+// actor_trading/types.mvl — Domain types for the verified trading engine.
+//
+// Demonstrates Req 10 (refinement types) + the MVL layered solver:
+//   - Price, Quantity, OrderId are type aliases documenting the domain constraints
+//   - Enforcement happens via inline `where` predicates on function parameters
+//     (see OrderGateway.new_bid / new_ask in main.mvl)
+//   - Struct fields use plain Int; values are valid once the gateway admits them
+//
+// Note: MVL type alias methods are resolved for arithmetic but not yet for
+// method dispatch (e.g. Price.to_string() resolves to Unknown). Use inline
+// `where` predicates on function parameters for enforcement (#954 for context).
+//
+// No extern, no effects — pure type declarations.
+
+// ── Refined scalar type aliases (documentation + function-param enforcement) ──
+//
+// These aliases name the domain constraints clearly.  They are used in
+// function signatures (as inline `where` predicates) to prove the predicates
+// statically at every call site.
+
+/// Positive integer price in ticks.
+pub type Price = Int where self > 0
+
+/// Positive integer quantity in lots.
+pub type Quantity = Int where self > 0
+
+/// Non-negative order identifier.
+pub type OrderId = Int where self >= 0
+
+// ── Enumerations ─────────────────────────────────────────────────────────
+
+/// Side of the market.
+pub type Side = enum {
+    Bid,    // buy order — willing to pay up to `price`
+    Ask,    // sell order — willing to sell down to `price`
+}
+
+/// Lifecycle state of an order.
+pub type OrderStatus = enum {
+    Open,       // resting in the order book
+    Filled,     // fully executed — no quantity remaining
+    Cancelled,  // withdrawn before full execution
+}
+
+// ── Aggregate types ───────────────────────────────────────────────────────
+
+/// An order submitted to the gateway.
+///
+/// Fields use plain Int — values are already validated at the gateway's
+/// new_bid/new_ask call sites (inline `where` predicates enforced there).
+pub type Order = struct {
+    id:       Int,
+    side:     Side,
+    price:    Int,
+    quantity: Int,
+    status:   OrderStatus,
+}
+
+/// A single execution: bid order matched against ask order at `price`
+/// for `quantity` lots.
+///
+/// Cross-field invariants (proved by Z3 in verify.py):
+///   fill.price >= ask.price  AND  fill.price <= bid.price
+///   fill.quantity <= bid.quantity  AND  fill.quantity <= ask.quantity
+pub type Fill = struct {
+    bid_order: Int,
+    ask_order: Int,
+    price:     Int,
+    quantity:  Int,
+}


### PR DESCRIPTION
## Summary

A second, independent host for `mvl build --backend=wasm` output, outside a browser. `mvl-lang/mvl-playground` is currently the **only** thing anywhere that can execute this output — confirmed directly: `mvl run` doesn't accept `--backend=wasm` at all, and bare `wasmtime run` fails with `unknown import: runtime::memory has not been defined`, because the `runtime` import namespace (~60 hand-written functions) is a playground-specific convention, not a standard WASI world. So "does this MVL program actually run under the WASM backend" has never been testable for anything outside the playground's 12 curated examples.

## What it is

- `harness/mvl-runtime.js` — a **byte-faithful port** of `mvl-playground`'s `web/src/runtime/mvl-runtime.ts` (TS → plain JS, no logic changes). This tests the actual runtime the playground ships, not a reimplementation of it.
- `harness/run-example.mjs` — compiles, converts WAT→WASM via `wasm-tools parse` (the CLI-equivalent of the playground's own `wat::parse_bytes`), instantiates against the ported runtime + `@bjorn3/browser_wasi_shim` (same shim experiments 004-007 used — no browser needed for any of this), captures stdout/stderr.
- `run-tests.sh` — diffs captured output against `expected-stdout.txt` (captured from `mvl run main.mvl`, the native-backend ground truth).

## Test case: `actor_trading`

Chosen deliberately over another toy example — a real order-matching engine with two real actors, since `actor_pingpong` (the only actor example the playground currently curates) is already known to have WASM gaps.

## Result: FAIL, precisely located — and it's a new bug

Not a duplicate of the three already-tracked WASM gaps (mvl#2054/2055/2056 — none involve actor message routing). The module compiles clean (zero warnings, all 60 `runtime` imports satisfied) and runs correctly through the first (no-op) scenario, then traps with `memory access out of bounds` the instant a real actor-to-actor message gets routed:

```
order_book_submit → order_book_dispatch → __mvl_actor_route → __mvl_actor_pump → _start
```

**Ruled out before filing, not assumed**: not a missing import (trap is inside the module's own code); not a memory-capacity issue (reproduces identically at `initial: 1` — the playground's actual default — and `initial: 64`, and the module never emits `memory.grow` at all).

**Filed as [mvl-lang/mvl#2083](https://github.com/mvl-lang/mvl/issues/2083).**

## A bug found while building the harness itself

The compile step's own `WAT written to: ...` status line was leaking into the captured program output via `stdio: 'inherit'`. Piped and re-emitted on stderr instead, so a caller capturing this script's stdout gets exactly what the compiled program printed.

## Changes

### Added
- `experiments/008_mvl_example_wasm_harness/` — the harness, plus one test case

### Fixed
- Top-level `README.md` experiment table to include #008

## Testing

- [x] `./run-tests.sh` runs the `actor_trading` case, reports the real (failing) result with a full diff and stack trace
- [x] Clean-room rebuild (fresh `node_modules`, fresh `.wat`/`.wasm`) reproduces the identical crash location every time
- [x] Confirmed this is not a duplicate of mvl#2054/2055/2056 before filing

## Related Issues

Found and filed mvl-lang/mvl#2083.

---
🤖 *Generated with [Claude Code](https://claude.ai/code)*