### PR TITLE
fix: run-tests.sh auto-installs harness deps, was ERR_MODULE_NOT_FOUND on first real use

### DIFF
--- a/experiments/008_mvl_example_wasm_harness/run-tests.sh
+++ b/experiments/008_mvl_example_wasm_harness/run-tests.sh
@@ -10,6 +10,17 @@
 set -uo pipefail  # not -e: a failing test case is an expected, reported outcome, not a script error
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# Every other experiment in this repo installs its own deps from build.sh —
+# this one didn't, and it showed: verified from throwaway worktrees that
+# already had `npm install` run in them, never from a genuinely fresh
+# `git clone`/`git pull`, which is exactly how this was first actually used
+# for real and immediately failed with ERR_MODULE_NOT_FOUND.
+if [ ! -d harness/node_modules ]; then
+  echo "→ Installing harness dependencies (first run)..."
+  (cd harness && npm install --no-audit --no-fund >/dev/null)
+  echo
+fi
+
 FAIL=0
 for dir in test-cases/*/; do
   name="$(basename "$dir")"


### PR DESCRIPTION
## Summary

Every other experiment in this repo installs its own dependencies from `build.sh`. Experiment 008's `run-tests.sh` didn't — verified only from throwaway worktrees that already had `npm install` run in them, never from a genuinely fresh checkout. First time it was actually pulled and run for real (not from a `/tmp` worktree), it failed immediately:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@bjorn3/browser_wasi_shim'
```

Before ever reaching the actor-routing crash the harness exists to surface.

## Fix

`run-tests.sh` installs `harness/node_modules` on first run if missing, skips it on subsequent runs — matching the pattern every other experiment already uses.

## Testing

- [x] Verified from an actual fresh worktree with **no prior `npm install` anywhere** — confirms the fix auto-installs, then runs, and reproduces the real `actor_trading` crash
- [x] Ran a second time — confirmed it does not reinstall unnecessarily

---
🤖 *Generated with [Claude Code](https://claude.ai/code)*