### PR TITLE
feat: experiment 009 — native Rust host, in-process, no HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Reference: [AWS's Stealth Container Killer](https://aws.plainenglish.io/awss-ste
 | [006](experiments/006_worker_kill_switch/) | worker_kill_switch | done | `Worker.terminate()` against a genuine infinite loop — is it actually instant? (No — ~2.1s) |
 | [007](experiments/007_custom_runtime_vs_interpreter/) | custom_runtime_vs_interpreter | done | Hand-written 78-line JS runtime shim vs. componentize-py vs. Pyodide — artifact size, cold start, build complexity |
 | [008](experiments/008_mvl_example_wasm_harness/) | mvl_example_wasm_harness | done | Standalone (non-browser) host for `mvl build --backend=wasm` output — found a new actor-routing crash in `actor_trading` (mvl-lang/mvl#2083) |
+| [009](experiments/009_rust_native_host/) | rust_native_host | done | Native Rust host embedding `wasmtime` directly, no HTTP — checks a Medium article's "200µs" claim against true cold start and against its own methodology |
 
 ## Structure
 

--- a/experiments/009_rust_native_host/.gitignore
+++ b/experiments/009_rust_native_host/.gitignore
@@ -1,0 +1,2 @@
+# guest/target/, host/target/, Cargo.lock already covered by the
+# repo-root .gitignore.

--- a/experiments/009_rust_native_host/README.md
+++ b/experiments/009_rust_native_host/README.md
@@ -1,0 +1,102 @@
+# Experiment 009 — Native Rust Host, In-Process, No HTTP
+
+Prompted directly by [Erwin Hermanto's "WebAssembly on the Server"](https://medium.com/@erwindev/webassembly-on-the-server-why-im-betting-on-wasm-as-the-next-backend-primitive-e1d730480a7f):
+a Go program embedding `wazero` (a pure-Go WASM runtime) as a library, loading a
+user-provided plugin, and calling it directly — no container, no HTTP, no
+subprocess. That's a genuinely different architecture from anything else in this
+repo. Every WASM host built so far here is either a browser Worker
+(experiments 004–008) or a pre-built server treated as a black box
+(`wasmtime serve`, `spin up` in 001/003). Nobody had embedded a WASM runtime as a
+library in a native process and called a function directly, in-process.
+
+This experiment builds that missing architecture in Rust rather than Go — using
+the `wasmtime` crate directly, the same engine `wasmtime serve` already wraps
+elsewhere in this repo, just as a library instead of a CLI.
+
+## The methodological gap in the article, addressed directly
+
+The article's headline number — "200 microseconds, on average" — comes from a loop
+that compiles the module **once**, outside the timed loop, then measures 1,000
+iterations of instantiate+call+close inside an already-running, already-warm Go
+process. That's a real number, but it isn't a cold start in the sense the
+article's own opening story uses the word (SSH in, deploy, first request). This
+experiment measures both, and keeps them separate rather than picking one.
+
+## Results
+
+### True cold start (external wall-clock, includes OS process launch)
+
+| | Internal timer (engine init + compile + call) | External (`time`, includes OS process launch) |
+|---|---|---|
+| First invocation of a freshly-built binary | 3,886µs (3.9ms) | **190ms** |
+| Second invocation (OS file cache now warm) | 587µs | **4ms** |
+
+The ~186ms gap on the first run is not wasmtime — it's the OS loading a binary
+whose pages aren't in the file cache yet. It's real, it's what a genuinely cold
+deploy looks like, and no measurement taken from *inside* the process (as the
+article's does, and as this experiment's own `--single-shot` internal timer does)
+can see it, because the internal clock only starts after the OS has already
+finished exec'ing the binary. Reproduced identically across two independent
+clean-room builds.
+
+### Warm-loop benchmark (the article's own methodology, reproduced faithfully)
+
+```
+first iteration (includes any first-call JIT lag): 64-172us (varies by run)
+remaining 999 iterations: min=8-13us median=9-15us avg=10-15us max=18-101us
+```
+
+**~13x faster than the article's 200µs, and the honest reason isn't (only)
+"Rust is faster."** Two real differences, not one:
+
+1. **Different runtimes, different languages.** `wasmtime` is a mature,
+   Cranelift-JIT-backed engine, called here with zero FFI/cgo tax since both the
+   host and the runtime are Rust. `wazero` is a pure-Go *reimplementation* of a
+   WASM engine — no cgo either, but a different, younger compiler pipeline. Some
+   of the gap is genuinely "which engine, called from what."
+2. **This benchmark's payload does zero data marshalling.** `transform(i64) -> i64`
+   — one integer in, one integer out, no memory access at all. The article's
+   `Transform` function does real work crossing the boundary: `malloc`, write
+   input bytes into WASM linear memory, call, read output bytes back out. That
+   marshalling cost is real and this experiment's payload doesn't pay it —
+   experiments 007 and 008 already measure that cost (handle-based string
+   marshalling) and it is not free. **This number isolates pure call overhead,
+   not realistic call-with-data overhead** — a narrower, smaller thing than what
+   the article measured, and it would be dishonest to present it as a direct
+   "Rust beats Go by 13x" result without that caveat.
+
+## Usage
+
+```bash
+./build.sh
+./benchmark.sh
+# or directly:
+./host/target/release/wasm_host --single-shot
+./host/target/release/wasm_host --loop 5000
+```
+
+## Structure
+
+```
+009_rust_native_host/
+├── README.md
+├── build.sh
+├── benchmark.sh
+├── guest/
+│   ├── Cargo.toml           # wasm32-unknown-unknown, zero imports
+│   └── src/lib.rs           # transform(i64) -> i64 — deliberately trivial
+└── host/
+    ├── Cargo.toml           # wasmtime crate, no wasmtime-cli, no HTTP server
+    └── src/main.rs          # --single-shot (true cold start) / --loop N (warm)
+    # */target/ is build.sh output, gitignored
+```
+
+## What this doesn't test (yet)
+
+Realistic data marshalling (see caveat above), and running MVL's own compiled
+output (e.g. `mastermind`'s `score_guess`, already proven to compile clean to
+`wasm32-wasip1` — see experiment 010) through this same native host instead of a
+throwaway Rust payload. That would need porting `mvl-runtime.js`'s ~60 functions
+to Rust — a real, separate effort, not done here to keep this experiment's own
+question (does in-process native hosting look like the article claims) answerable
+on its own.

--- a/experiments/009_rust_native_host/benchmark.sh
+++ b/experiments/009_rust_native_host/benchmark.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# benchmark.sh — two measurements, kept deliberately separate rather than
+# collapsed into one number:
+#   1. True cold start: OS process launch -> compile -> instantiate -> call
+#      -> exit, measured externally (the shell's `time`, not the program's
+#      own clock, which only starts after the OS has already loaded and
+#      exec'd the binary).
+#   2. The article's own methodology: compile once, then loop N times over
+#      fresh Store+Instance+call+drop, all inside one already-running
+#      process — reproduced faithfully so its number is checkable.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "→ Building..."
+./build.sh >/dev/null
+
+BIN=./host/target/release/wasm_host
+
+echo
+echo "=== True cold start (external wall-clock, includes OS process launch) ==="
+echo "First invocation of this freshly-built binary:"
+{ time "$BIN" --single-shot ; } 2>&1
+echo
+echo "Second invocation (OS file cache now warm from the first run):"
+{ time "$BIN" --single-shot ; } 2>&1
+
+echo
+echo "=== Warm-loop benchmark (article's own methodology: compile once, loop N) ==="
+"$BIN" --loop 1000

--- a/experiments/009_rust_native_host/build.sh
+++ b/experiments/009_rust_native_host/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "→ Compiling guest/ to wasm32-unknown-unknown..."
+(cd guest && cargo build --target wasm32-unknown-unknown --release)
+echo "  wrote guest/target/wasm32-unknown-unknown/release/transform_guest.wasm ($(wc -c < guest/target/wasm32-unknown-unknown/release/transform_guest.wasm) bytes)"
+
+echo "→ Compiling host/ (embeds the wasmtime crate)..."
+(cd host && cargo build --release)
+
+echo "→ Done."

--- a/experiments/009_rust_native_host/guest/Cargo.toml
+++ b/experiments/009_rust_native_host/guest/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "transform_guest"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = "z"
+lto = true
+strip = true
+panic = "abort"

--- a/experiments/009_rust_native_host/guest/src/lib.rs
+++ b/experiments/009_rust_native_host/guest/src/lib.rs
@@ -1,0 +1,10 @@
+// The payload — deliberately trivial and import-free, mirroring the
+// article's own example ("amount * 1.15, add a markup"). The point of this
+// experiment is measuring instantiate+call+teardown overhead in a native
+// host, not marshalling cost or runtime-import cost (those are what
+// experiments 007/008 already measure) — a zero-import module isolates
+// exactly the cost this experiment exists to find.
+#[no_mangle]
+pub extern "C" fn transform(amount_cents: i64) -> i64 {
+    amount_cents + (amount_cents * 15 / 100)
+}

--- a/experiments/009_rust_native_host/host/Cargo.toml
+++ b/experiments/009_rust_native_host/host/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wasm_host"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "wasm_host"
+path = "src/main.rs"
+
+[dependencies]
+wasmtime = "27"
+
+[profile.release]
+opt-level = 3

--- a/experiments/009_rust_native_host/host/src/main.rs
+++ b/experiments/009_rust_native_host/host/src/main.rs
@@ -1,0 +1,85 @@
+// wasm_host — a native Rust process that embeds `wasmtime` as a library,
+// not a CLI subprocess and not an HTTP server. This is the missing fourth
+// architecture in this repo: experiments 004-008 host WASM in a browser
+// Worker; 001/003 treat `wasmtime serve`/`spin up` as a black-box HTTP
+// server. Nothing until now has measured a direct, in-process function
+// call with no network layer between the caller and the WASM instance —
+// which is exactly what the article this experiment responds to actually
+// benchmarked, and exactly the number its own methodology doesn't fully
+// justify (see README).
+//
+// Two modes:
+//   --single-shot   Full init -> compile -> instantiate -> call -> exit,
+//                    once. Meant to be wrapped by an external wall-clock
+//                    timer (the benchmark script), so "cold start" means
+//                    what it should: everything, including process launch,
+//                    not just a warm loop inside an already-running process.
+//   --loop N        Compile once, then N iterations of fresh Store +
+//                    Instance + call + drop, each timed individually.
+//                    This is the article's own methodology, reproduced
+//                    faithfully so its number is directly checkable rather
+//                    than taken on faith -- with the first iteration
+//                    reported separately from the rest, since bundling it
+//                    into one average is exactly the thing that made the
+//                    article's number read as "cold" when it wasn't.
+use std::env;
+use std::time::Instant;
+use wasmtime::{Engine, Instance, Module, Store};
+
+const WASM_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../guest/target/wasm32-unknown-unknown/release/transform_guest.wasm");
+
+fn call_transform(engine: &Engine, module: &Module, input: i64) -> i64 {
+    let mut store = Store::new(engine, ());
+    let instance = Instance::new(&mut store, module, &[]).expect("instantiate");
+    let func = instance
+        .get_typed_func::<i64, i64>(&mut store, "transform")
+        .expect("get transform");
+    func.call(&mut store, input).expect("call transform")
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mode = args.get(1).map(String::as_str).unwrap_or("--single-shot");
+
+    if mode == "--single-shot" {
+        let t0 = Instant::now();
+        let engine = Engine::default();
+        let module = Module::from_file(&engine, WASM_PATH).expect("compile module");
+        let result = call_transform(&engine, &module, 10000);
+        let elapsed = t0.elapsed();
+        // Everything: engine init, first-ever module compile, instantiate,
+        // call. This is the number "cold start" should mean.
+        println!("single-shot: result={result} elapsed_us={}", elapsed.as_micros());
+        return;
+    }
+
+    // --loop N
+    let n: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
+
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, WASM_PATH).expect("compile module");
+
+    let mut times_us: Vec<u128> = Vec::with_capacity(n);
+    for _ in 0..n {
+        let t0 = Instant::now();
+        let _ = call_transform(&engine, &module, 10000);
+        times_us.push(t0.elapsed().as_micros());
+    }
+
+    let first = times_us[0];
+    let rest = &times_us[1..];
+    let mut sorted_rest = rest.to_vec();
+    sorted_rest.sort_unstable();
+    let median = sorted_rest[sorted_rest.len() / 2];
+    let min = *sorted_rest.first().unwrap();
+    let max = *sorted_rest.last().unwrap();
+    let sum: u128 = sorted_rest.iter().sum();
+    let avg = sum / sorted_rest.len() as u128;
+
+    println!("loop: n={n}");
+    println!("  first iteration (includes any first-call JIT lag): {first}us");
+    println!("  remaining {} iterations: min={min}us median={median}us avg={avg}us max={max}us", sorted_rest.len());
+}


### PR DESCRIPTION
## Summary

Prompted by [Erwin Hermanto's "WebAssembly on the Server"](https://medium.com/@erwindev/webassembly-on-the-server-why-im-betting-on-wasm-as-the-next-backend-primitive-e1d730480a7f), claiming ~200µs average cold start via Go + wazero. Every host built so far in this repo is either a browser Worker (004–008) or a pre-built server treated as a black box (`wasmtime serve`/`spin up`, 001/003) — nobody had embedded a WASM runtime as a library in a native process and called a function directly, no HTTP, no subprocess. Built that missing architecture in Rust (`wasmtime` crate directly) rather than replicating the article in Go.

## Two measurements, kept separate rather than collapsed into one number

**1. True cold start (external wall-clock)**

| | Internal timer | External (`time`) |
|---|---|---|
| First invocation, freshly built | 3.9ms | **~190ms** |
| Second invocation, OS cache warm | 0.6-1.1ms | **~4-7ms** |

The ~186ms gap is OS binary-loading, invisible to any measurement taken from inside the process — which is exactly how the article's own number was taken.

**2. The article's own methodology, reproduced faithfully**

Compile once, loop N times over fresh `Store`+`Instance`+call+drop: **~9-15µs median**, roughly **13x faster** than the article's 200µs claim — not presented as a clean "Rust beats Go" result, since two real differences explain most of the gap: different runtimes (`wasmtime`/Cranelift vs. `wazero`, a younger pure-Go engine), and this payload does **zero data marshalling** (`i64` in, `i64` out) while the article's does real `malloc`+write+read across the boundary — a cost experiments 007/008 already show is not free.

## Changes

### Added
- `experiments/009_rust_native_host/` — Rust guest (zero imports) + Rust host embedding `wasmtime`

### Fixed
- Top-level `README.md` experiment table to include #009

## Testing

- [x] `./benchmark.sh` runs both cold-start and warm-loop measurements
- [x] Two independent clean-room builds reproduce the same cold/warm gap shape and ~9-15µs loop numbers

---
🤖 *Generated with [Claude Code](https://claude.ai/code)*