### PR TITLE
fix: Option/Result tag polarity was inverted in mvl-runtime.js

### DIFF
--- a/experiments/008_mvl_example_wasm_harness/README.md
+++ b/experiments/008_mvl_example_wasm_harness/README.md
@@ -84,6 +84,53 @@ not in a call to the JS runtime.
 
 **Filed as [mvl-lang/mvl#2083](https://github.com/mvl-lang/mvl/issues/2083).** New bug, not a duplicate — checked all three related issues before filing.
 
+## Fix: Option/Result tag polarity was inverted (found while building experiment 010)
+
+While building experiment 010 (mastermind_web), reverse-engineering the WASM ABI
+for a struct-returning function required reading the compiler's actual WAT output
+for a trivial probe (`xs.get(i).unwrap_or(dflt)`). That surfaced the compiled code:
+
+```wat
+call $_mvl_option_tag
+i32.eqz
+if (result i64)          ;; taken when tag == 0
+  call $_mvl_option_value_i64
+else                      ;; taken when tag != 0
+  local.get $dflt
+end
+```
+
+`i32.eqz` branches on `tag == 0`, and that branch is the one that reads the value —
+so the compiler's real convention is **0 = Some/Ok (has a value), 1 = None/Err**.
+
+This harness's `mvl-runtime.js` (and, checked directly, `mvl-lang/mvl-playground`'s
+actual production `web/src/runtime/mvl-runtime.ts`, lines 236-238 and 304 at the time
+of writing) had it backwards: `_mvl_option_some_i64/i32` stored tag `1`,
+`_mvl_option_none` stored tag `0`, `_mvl_array_get_option_i64/i32` and
+`_mvl_map_get_si64` used found=`1`/not-found=`0`, and the equivalent Result
+functions (`_mvl_result_ok_*`/`_mvl_result_err_str`, used by
+`_mvl_string_parse_int`) had the same inversion.
+
+**Effect: silently wrong values, not a crash.** A present element compared as
+absent (falling through to the `unwrap_or` default) and vice versa — for
+`.get(i).unwrap_or(...)`, map lookups, and `String.parse_int()` alike. Verified
+both directions empirically with isolated single-function probes
+(`xs.get(i).unwrap_or(dflt)` and `s.parse_int().unwrap_or(dflt)`) before and after
+the fix, not assumed from reading code.
+
+**Fixed here**: flipped the tag argument in every `storeOption`/`storeResult` call
+in `harness/mvl-runtime.js`, including the `?? 0` fallback in `_mvl_option_tag`/
+`_mvl_result_tag` (now `?? 1`, so a missing/invalid handle fails safe to
+None/Err instead of defaulting to Some/Ok).
+
+**Regression test**: `test-cases/option_probe/` — a minimal `.get().unwrap_or()`
+program that fails (both directions) against the pre-fix runtime and passes
+against the fix (verified both ways via `git stash` before committing).
+
+**Not fixed here**: `mvl-lang/mvl-playground`'s own `runtime.ts` has the identical
+bug and is production code — out of scope for this repo to patch directly, flagged
+separately.
+
 ## Usage
 
 ```bash

--- a/experiments/008_mvl_example_wasm_harness/harness/mvl-runtime.js
+++ b/experiments/008_mvl_example_wasm_harness/harness/mvl-runtime.js
@@ -133,9 +133,9 @@ export function createMvlRuntime() {
       const s = readString(ptr, len).trim();
       const n = Number(s);
       if (s !== "" && !isNaN(n) && Number.isInteger(n)) {
-        return storeResult(1, BigInt(n));
+        return storeResult(0, BigInt(n));
       }
-      return storeResult(0, 0n, `invalid integer: "${s}"`);
+      return storeResult(1, 0n, `invalid integer: "${s}"`);
     },
 
     // ── Array functions (handle-based) ────────────────────────────────
@@ -230,12 +230,26 @@ export function createMvlRuntime() {
     },
 
     // ── Option functions ─────────────────────────────────────────────
+    //
+    // Tag convention: 0 = Some (has a value), 1 = None. Verified empirically
+    // against the compiler's actual WAT output (not assumed): a minimal
+    // `xs.get(i).unwrap_or(dflt)` compiles to
+    //   call $_mvl_option_tag / i32.eqz / if (result i64)   <- Some branch
+    //     call $_mvl_option_value_i64
+    //   else                                                 <- None branch
+    //     local.get $dflt
+    // i32.eqz branches on tag==0, and that branch reads the value — so
+    // tag==0 must mean Some. This was previously inverted here (0=None,
+    // 1=Some, matching mvl-playground's runtime.ts) which silently returned
+    // wrong values (not a crash) for every unwrap_or/Option-consuming call.
+    // See experiments/008_mvl_example_wasm_harness/README.md for the fix
+    // writeup and probe script.
 
-    _mvl_option_some_i64: (val) => storeOption(1, val),
-    _mvl_option_some_i32: (val) => storeOption(1, val),
-    _mvl_option_none: () => storeOption(0, 0),
+    _mvl_option_some_i64: (val) => storeOption(0, val),
+    _mvl_option_some_i32: (val) => storeOption(0, val),
+    _mvl_option_none: () => storeOption(1, 0),
 
-    _mvl_option_tag: (h) => options.get(h)?.tag ?? 0,
+    _mvl_option_tag: (h) => options.get(h)?.tag ?? 1,
 
     _mvl_option_value_i64: (h) => {
       const opt = options.get(h);
@@ -253,27 +267,30 @@ export function createMvlRuntime() {
 
     _mvl_array_get_option_i64: (h, idx) => {
       const arr = arrays.get(h);
-      if (!arr) return storeOption(0, 0);
+      if (!arr) return storeOption(1, 0);
       const i = Number(idx);
-      if (i < 0 || i >= arr.length) return storeOption(0, 0);
-      return storeOption(1, BigInt(arr[i]));
+      if (i < 0 || i >= arr.length) return storeOption(1, 0);
+      return storeOption(0, BigInt(arr[i]));
     },
 
     _mvl_array_get_option_i32: (h, idx) => {
       const arr = arrays.get(h);
-      if (!arr) return storeOption(0, 0);
+      if (!arr) return storeOption(1, 0);
       const i = Number(idx);
-      if (i < 0 || i >= arr.length) return storeOption(0, 0);
-      return storeOption(1, arr[i]);
+      if (i < 0 || i >= arr.length) return storeOption(1, 0);
+      return storeOption(0, arr[i]);
     },
 
     // ── Result functions ──────────────────────────────────────────────
+    //
+    // Same tag inversion fix as Option, verified the same way (a minimal
+    // `s.parse_int().unwrap_or(dflt)` probe): 0 = Ok, 1 = Err.
 
-    _mvl_result_ok_i64: (val) => storeResult(1, val),
-    _mvl_result_ok_i32: (val) => storeResult(1, val),
-    _mvl_result_err_str: (ptr, len) => storeResult(0, 0, readString(ptr, len)),
+    _mvl_result_ok_i64: (val) => storeResult(0, val),
+    _mvl_result_ok_i32: (val) => storeResult(0, val),
+    _mvl_result_err_str: (ptr, len) => storeResult(1, 0, readString(ptr, len)),
 
-    _mvl_result_tag: (h) => results.get(h)?.tag ?? 0,
+    _mvl_result_tag: (h) => results.get(h)?.tag ?? 1,
 
     _mvl_result_value_i64: (h) => {
       const r = results.get(h);
@@ -301,10 +318,10 @@ export function createMvlRuntime() {
 
     _mvl_map_get_si64: (h, kp, kl) => {
       const m = maps.get(h);
-      if (!m) return storeOption(0, 0);
+      if (!m) return storeOption(1, 0);
       const val = m.get(readString(kp, kl));
-      if (val === undefined) return storeOption(0, 0);
-      return storeOption(1, BigInt(val));
+      if (val === undefined) return storeOption(1, 0);
+      return storeOption(0, BigInt(val));
     },
 
     _mvl_map_contains_key_si64: (h, kp, kl) =>

--- a/experiments/008_mvl_example_wasm_harness/test-cases/option_probe/expected-stdout.txt
+++ b/experiments/008_mvl_example_wasm_harness/test-cases/option_probe/expected-stdout.txt
@@ -1,0 +1,2 @@
+in_bounds: correct (found 20)
+out_of_bounds: correct (default -1)

--- a/experiments/008_mvl_example_wasm_harness/test-cases/option_probe/main.mvl
+++ b/experiments/008_mvl_example_wasm_harness/test-cases/option_probe/main.mvl
@@ -1,0 +1,29 @@
+// option_probe/main.mvl — minimal regression test for a real bug found while
+// building experiment 010 (mastermind_web): the ported runtime's Option/
+// Result tag polarity was inverted (0=None/1=Some instead of the compiler's
+// actual 0=Some/1=None), which silently returned WRONG values for every
+// .get(i).unwrap_or(...) call instead of crashing. This test exists so that
+// regression is caught by run-tests.sh going forward instead of needing to
+// be rediscovered by hand.
+//
+// Deliberately avoids Int.to_string() — under --backend=wasm that call
+// compiles to an undefined `$mvl_int_to_string` and fails to assemble at
+// all (a separate, also-real, already-documented gap). Comparing against
+// fixed constants sidesteps it without weakening the Option-tag coverage.
+fn main() -> Unit ! Console {
+    let xs: List[Int] = [10, 20, 30];
+    let in_bounds: Int = xs.get(1).unwrap_or(-1);
+    let out_of_bounds: Int = xs.get(9).unwrap_or(-1);
+
+    if in_bounds == 20 {
+        println("in_bounds: correct (found 20)")
+    } else {
+        println("in_bounds: WRONG (Option tag polarity bug)")
+    };
+
+    if out_of_bounds == -1 {
+        println("out_of_bounds: correct (default -1)")
+    } else {
+        println("out_of_bounds: WRONG (Option tag polarity bug)")
+    }
+}


### PR DESCRIPTION
## Summary

- Found while building experiment 010 (mastermind_web): the compiler's real tag convention for Option/Result is `0 = Some/Ok`, `1 = None/Err` — confirmed directly by reading the WAT output of an isolated `xs.get(i).unwrap_or(dflt)` probe (`i32.eqz` on the tag branches to the value-read side).
- `harness/mvl-runtime.js` had it backwards (`0=None/1=Some`), inherited from a byte-faithful port of `mvl-lang/mvl-playground`'s own `web/src/runtime/mvl-runtime.ts` — which has the identical bug in production (checked directly, not fixed here, out of scope for this repo).
- Effect: silently WRONG values, not a crash, for every `.get(i).unwrap_or(...)`, map lookup, and `String.parse_int()` call.

## Changes

### Fixed
- Flipped tag args in every `storeOption`/`storeResult` call in `harness/mvl-runtime.js`, including the `?? 0` → `?? 1` fallback so a missing handle fails safe to None/Err.

### Added
- `test-cases/option_probe/` — minimal regression test. Confirmed it fails (both directions) against the pre-fix runtime and passes against the fix via `git stash`.

## Testing

- [x] `./run-tests.sh` — `option_probe` PASS, `actor_trading` shows the identical pre-existing unrelated crash (mvl#2083), no regression
- [x] Verified fix both ways with `git stash` on `mvl-runtime.js`
- [x] Clean-room: fresh worktree off `origin/main`, no manual npm install carried over

No CI configured in this repo (confirmed via `gh pr checks`), merging directly once reviewed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>