### PR TITLE
fix: struct/array-get/string-creator memory bug that was actually mvl#2083

### DIFF
--- a/experiments/008_mvl_example_wasm_harness/README.md
+++ b/experiments/008_mvl_example_wasm_harness/README.md
@@ -53,36 +53,20 @@ Chosen deliberately as something with real complexity, not another hello-world:
 (`OrderBook`, `Matcher`), not the toy ping-pong of `actor_pingpong` (the only
 actor-based example currently curated into the playground).
 
-**Result: FAIL, precisely located.**
+**Original result (superseded below): FAIL, filed as [mvl-lang/mvl#2083](https://github.com/mvl-lang/mvl/issues/2083)** —
+a trap in `order_book_submit` during the first actor-to-actor message dispatch, with
+what looked like solid evidence it wasn't a missing import, a memory-capacity issue,
+or one of three already-tracked WASM gaps. **That issue has since been corrected and
+closed — see "Fix: `_mvl_struct_alloc`/`_mvl_array_get`" below. It was a bug in this
+harness, not the compiler.** Left the original repro details out of this README
+(they're preserved in the issue's history) since they'd otherwise read as evidence
+for a conclusion this file no longer holds.
 
-```
-=== actor_trading ===
-  FAIL — output diverges from mvl run (native backend)
-  --- diff (expected vs actual) ---
-  4,19d3
-  < 
-  < --- scenario 2: resting bid crossed by aggressive ask ---
-  < OrderBook: ask 0 price=100 qty=10
-  ... [rest of scenarios 2-3 never printed]
-  --- runtime error ---
-      at order_book_submit (wasm://.../wasm-function[66]:0xbbe)
-      at order_book_dispatch (wasm://.../wasm-function[67]:0xc46)
-      at __mvl_actor_route (wasm://.../wasm-function[75]:0xf6b)
-      at __mvl_actor_pump (wasm://.../wasm-function[76]:0xfb1)
-      at _start (wasm://.../wasm-function[79]:0x1091)
-```
-
-The module compiles cleanly (no warnings, all 60 `runtime` imports satisfied) and
-runs correctly right up until the first real actor-to-actor message dispatch, then
-traps with `memory access out of bounds` inside the compiled module's own code —
-not in a call to the JS runtime.
-
-**Ruled out before filing, not assumed:**
-- Not a missing import — the crash is inside `order_book_submit`, not at a call boundary into JS.
-- Not a memory-capacity issue — reproduces identically at `initial: 1` (64KB, the playground's actual default) and `initial: 64` (4MB). The module never emits `memory.grow` (`grep -c memory.grow main.wat` = 0), so more memory can't help; something computes or dereferences a wrong address.
-- Not one of the three already-tracked WASM gaps (mvl#2054 extension methods, #2055 `std.env.exit`, #2056 `std.log`) — none involve actor message routing.
-
-**Filed as [mvl-lang/mvl#2083](https://github.com/mvl-lang/mvl/issues/2083).** New bug, not a duplicate — checked all three related issues before filing.
+**Current result, after both runtime fixes below: no crash.** All three scenarios
+run to completion, and every printed value (prices, quantities, bid/ask ids, fill
+messages) matches a native `mvl run main.mvl` execution exactly. The one remaining
+difference is explained in "A genuine backend difference: actor output ordering" —
+it isn't a bug, and isn't what #2083 was about.
 
 ## Fix: Option/Result tag polarity was inverted (found while building experiment 010)
 
@@ -130,6 +114,86 @@ against the fix (verified both ways via `git stash` before committing).
 **Not fixed here**: `mvl-lang/mvl-playground`'s own `runtime.ts` has the identical
 bug and is production code — out of scope for this repo to patch directly, flagged
 separately.
+
+## Fix: `_mvl_struct_alloc`/`_mvl_array_get`/string-creation functions used a handle table instead of real memory (this closed and corrected mvl#2083)
+
+Found the same way as the Option/Result fix above: reverse-engineering `score_guess`'s
+WASM ABI for experiment 010 required reading its actual WAT body. That surfaced:
+
+```wat
+i32.const 16
+call $_mvl_struct_alloc
+local.set $__st
+local.get $__st
+local.get $blacks
+i64.store offset=0        ;; raw store directly on _mvl_struct_alloc's return value
+local.get $__st
+local.get $whites
+i64.store offset=8
+```
+
+`_mvl_struct_alloc`'s return value is **not** an opaque handle the compiled module
+hands back to JS to interpret — the module itself does raw `i64.store`/`i64.load` on
+it. It has to be a real address in the shared linear memory. Same pattern confirmed
+for two more import functions by reading their call sites: `_mvl_array_get` (used by
+`for x in [array literal]` loops — `call $_mvl_array_get` / `i64.load offset=0`) and
+every string-*creating* function (`_mvl_string_new/concat/substring/to_upper/
+to_lower/trim/replace` — `s.concat(s)` compiles to `call $_mvl_string_concat` /
+`i32.load offset=0` (ptr) / `i32.load offset=4` (len), an 8-byte `{ptr, len}`
+descriptor record in memory, not a handle).
+
+This harness's `mvl-runtime.js` used the same handle-table pattern (a shared
+`nextHandle` counter) for **all** `_mvl_*_alloc`/`_mvl_*_new`-style functions,
+correct for the ones only ever read back through another runtime *function call*
+(`_mvl_option_value_i64`, `_mvl_array_get_option_i64`, etc. — genuinely fine as JS
+Map keys) but wrong for these three, whose return values the compiled module
+dereferences directly as memory addresses. A handle like `3` used as a raw address
+corrupts real module memory — those low addresses overlap static rodata and other
+live data in any nontrivial module.
+
+**This is what #2083 actually was.** `actor_trading`'s `main.wat` calls
+`$_mvl_struct_alloc` 18 times (`Order` and `Fill` are both structs) — this harness
+had been running that test against a broken allocator for the entire time the crash
+was diagnosed and filed as an "actor message routing" compiler bug. After this fix:
+no crash, full run to completion, output values matching native exactly. **Issue
+closed with a correcting comment** — see the commit/PR for the link. Own the
+mistake: should have ruled out the harness's own allocator more thoroughly before
+filing against the compiler.
+
+**Fixed here**: `_mvl_struct_alloc` and `_mvl_array_get` now use a real bump
+allocator (`bumpAllocScratch`) into the shared `WebAssembly.Memory`, starting at a
+fixed offset (32KB — comfortably above any static rodata a realistically-sized
+example emits, and inside the initial 64KB page so no `memory.grow` is needed for
+typical small examples) and growing memory on demand for larger ones.
+String-creating functions now encode to UTF-8, write the bytes into that same
+scratch space, and return a `{ptr, len}` descriptor pointer instead of a Map handle.
+Never frees (fine for a short-lived test-harness process, not a real GC — documented
+as a limitation, not silently swept under the rug).
+
+**Not fixed here**: `mvl-lang/mvl-playground`'s own `runtime.ts` has the identical
+`_mvl_struct_alloc` handle-table bug (checked directly) — production code, out of
+scope for this repo, flagged separately alongside the Option/Result bug.
+
+## A genuine backend difference: actor console-output ordering is nondeterministic in native, deterministic in WASM
+
+After the fix above, `actor_trading`'s WASM output still doesn't byte-diff clean
+against the checked-in `expected-stdout.txt` — but the reason turned out to be a
+property of the *native* backend, not a WASM defect. Running `mvl run main.mvl`
+three times back to back produces **two different outputs** (confirmed via
+`md5`sum of three consecutive runs: run 1 and run 3 matched, run 2 didn't) — actor
+mailbox draining interleaves nondeterministically with the driving code's own
+`println` calls natively. Running the WASM harness three times back to back
+produces the **same output every time** — the compiled module's actor pump appears
+to run each mailbox fully synchronously in-order, with no interleaving to be
+nondeterministic about.
+
+Practically: comparing WASM output against a single captured native run is not a
+meaningful correctness bar for this actor-based example — the "expected" file itself
+isn't stable. The values are what matter (and they match), not the interleaving
+order. Left `expected-stdout.txt` as originally captured (one valid native ordering
+among several) rather than chase a moving target; `run-tests.sh` will keep reporting
+this specific case as FAIL on ordering, which is now a documented, understood
+non-issue rather than an open question.
 
 ## Usage
 

--- a/experiments/008_mvl_example_wasm_harness/harness/mvl-runtime.js
+++ b/experiments/008_mvl_example_wasm_harness/harness/mvl-runtime.js
@@ -24,28 +24,103 @@ function newHandle() {
   return nextHandle++;
 }
 
+// Bump allocator for structs, carving real linear-memory addresses.
+//
+// Found while building experiment 010 (mastermind_web) and reverse-
+// engineering score_guess's WAT: `_mvl_struct_alloc`'s return value is NOT
+// treated as an opaque JS-side handle by the compiled module — the WASM
+// code does raw `i64.store offset=N` / `i64.load offset=N` directly on it
+// (e.g. score_guess writes Feedback.blacks/whites at +0/+8 of whatever
+// _mvl_struct_alloc returned; render_feedback reads a Feedback struct back
+// the same way). A JS-side handle-table index (1, 2, 3, ...) used as a raw
+// memory address corrupts real module memory — those low addresses overlap
+// static rodata (string literals, etc.) in any nontrivial module.
+//
+// This previously used the same handle-table pattern as every other
+// _mvl_*_alloc/new function here (fine for those — arrays/strings/options
+// are only ever read back through a runtime FUNCTION CALL, e.g.
+// _mvl_option_value_i64, never via raw i64.load on the handle itself).
+// Structs are the one exception: verified directly via an isolated
+// score_guess probe that a real bump allocator is required, a handle
+// table silently produces garbage.
+//
+// This candidate root-causing actor_trading's crash (mvl-lang/mvl#2083,
+// filed before this fix existed): actor_trading's main.wat calls
+// $_mvl_struct_alloc 18 times (Order/Fill are both structs), so this
+// harness had been running that test against a broken allocator the whole
+// time the "actor message routing" bug was diagnosed and filed. Re-run
+// after this fix, below, to check whether the crash is actually this bug
+// instead.
+//
+// Starts at 1MB — far above any static data a realistically-sized example
+// module would emit — and grows the shared memory on demand. Never frees;
+// fine for a short-lived test-harness process, not fine for a long-running
+// host (documented in README).
+const SCRATCH_HEAP_BASE = 32768;
+const PAGE_SIZE = 65536;
+
 export function createMvlRuntime() {
   const memory = new WebAssembly.Memory({ initial: 1, maximum: 256 });
   const u8 = () => new Uint8Array(memory.buffer);
 
-  const strings = new Map();
+  let scratchHeapPtr = SCRATCH_HEAP_BASE;
+  function bumpAllocScratch(size) {
+    const end = scratchHeapPtr + size;
+    const neededPages = Math.ceil(end / PAGE_SIZE);
+    const currentPages = memory.buffer.byteLength / PAGE_SIZE;
+    if (neededPages > currentPages) {
+      memory.grow(neededPages - currentPages);
+    }
+    const ptr = scratchHeapPtr;
+    scratchHeapPtr = (end + 7) & ~7; // 8-byte align, matches typical wasm ABI expectations
+    return ptr;
+  }
+
   const arrays = new Map();
   const options = new Map();
   const results = new Map();
   const maps = new Map();
-  const structs = new Map();
 
   const decoder = new TextDecoder("utf-8");
+  const encoder = new TextEncoder();
 
   function readString(ptr, len) {
     if (len <= 0) return "";
     return decoder.decode(u8().subarray(ptr, ptr + len));
   }
 
+  // String-CREATING functions (_mvl_string_new/clone/concat/substring/
+  // to_upper/to_lower/trim/replace) hit the exact same bug as
+  // _mvl_struct_alloc/_mvl_array_get (see comment above bumpAllocScratch):
+  // their return value is read back via raw `i32.load offset=0`
+  // (data ptr) / `i32.load offset=4` (byte len) directly on the compiled
+  // module side, e.g. `s.concat(s)` compiles to
+  //   call $_mvl_string_concat
+  //   local.tee $tmp / i32.load offset=0 / ... / i32.load offset=4
+  // — an 8-byte {ptr:i32, len:i32} descriptor in real linear memory, NOT a
+  // JS-side string handle. storeString/strings-map (as still used by every
+  // OTHER experiment 008 test case that never exercised .concat()-style
+  // chains) silently produced garbage here for the same reason structs did.
+  // Fixed the same way: write the UTF-8 bytes into scratch memory, write an
+  // 8-byte descriptor pointing at them, return the descriptor's address.
   function storeString(s) {
-    const h = newHandle();
-    strings.set(h, s);
-    return h;
+    const bytes = encoder.encode(s);
+    const dataPtr = bumpAllocScratch(bytes.length);
+    if (bytes.length > 0) u8().set(bytes, dataPtr);
+    const descPtr = bumpAllocScratch(8);
+    const dv = new DataView(memory.buffer);
+    dv.setInt32(descPtr, dataPtr, true);
+    dv.setInt32(descPtr + 4, bytes.length, true);
+    return descPtr;
+  }
+
+  // Read back a string previously created by storeString, given its
+  // descriptor pointer (NOT a JS handle — see storeString above).
+  function readStoredString(descPtr) {
+    const dv = new DataView(memory.buffer);
+    const dataPtr = dv.getInt32(descPtr, true);
+    const len = dv.getInt32(descPtr + 4, true);
+    return readString(dataPtr, len);
   }
 
   function storeArray(a) {
@@ -100,14 +175,18 @@ export function createMvlRuntime() {
 
     _mvl_string_new: (ptr, len) => storeString(readString(ptr, len)),
 
-    _mvl_string_clone: (h) => {
-      const s = strings.get(h);
-      return s !== undefined ? storeString(s) : storeString("");
-    },
+    // No confirmed call site (String has no .clone() method reachable from
+    // MVL source as of this compiler version — verified: `s.clone()`
+    // produces "no method `clone` on type `String`"). Kept for import
+    // completeness, consistent with the descriptor convention in case a
+    // future compiler version emits it. Takes a descriptor pointer, not a
+    // JS handle.
+    _mvl_string_clone: (descPtr) => storeString(readStoredString(descPtr)),
 
-    _mvl_string_drop: (h) => {
-      strings.delete(h);
-    },
+    // Never frees (see bumpAllocScratch) — fine for a short-lived harness
+    // process, not a real GC. h is a descriptor pointer now, not a handle;
+    // nothing to look up or delete.
+    _mvl_string_drop: (_descPtr) => {},
 
     _mvl_string_concat: (p1, l1, p2, l2) =>
       storeString(readString(p1, l1) + readString(p2, l2)),
@@ -162,11 +241,26 @@ export function createMvlRuntime() {
       arrays.get(h)?.push(val);
     },
 
+    // Same raw-pointer convention as _mvl_struct_alloc (see top-of-file
+    // comment): the WAT for a `for x in [literal, array]` loop does
+    // `call $_mvl_array_get / i64.load offset=0` on the return value, so
+    // this must return a real memory address holding the element, not the
+    // element itself. Contrast with _mvl_array_get_option_i64/i32 below,
+    // which ARE read back through a runtime function call
+    // (_mvl_option_value_i64/i32) and so are safe as JS-side handles.
+    // Writes at the width matching how the element was pushed (i64 as
+    // BigInt, i32/f64 as Number) so whichever *.load the caller uses reads
+    // the right bytes.
     _mvl_array_get: (h, idx) => {
       const arr = arrays.get(h);
-      if (!arr) return 0;
       const i = Number(idx);
-      return i >= 0 && i < arr.length ? arr[i] : 0;
+      const val = arr && i >= 0 && i < arr.length ? arr[i] : 0;
+      const ptr = bumpAllocScratch(8);
+      const dv = new DataView(memory.buffer);
+      if (typeof val === "bigint") dv.setBigInt64(ptr, val, true);
+      else if (Number.isInteger(val)) dv.setInt32(ptr, val, true);
+      else dv.setFloat64(ptr, val, true);
+      return ptr;
     },
 
     _mvl_array_clone: (h) => {
@@ -333,11 +427,9 @@ export function createMvlRuntime() {
 
     // ── Struct ─────────────────────────────────────────────────────────
 
-    _mvl_struct_alloc: (size) => {
-      const h = newHandle();
-      structs.set(h, new Uint8Array(size));
-      return h;
-    },
+    // Real bump allocator into linear memory — see the top-of-file comment.
+    // NOT a handle-table index like every other _mvl_*_alloc/new here.
+    _mvl_struct_alloc: (size) => bumpAllocScratch(size),
 
     // ── Audit (no-op — this harness doesn't persist an audit trail) ───
 


### PR DESCRIPTION
## Summary

- Found while building experiment 010: `_mvl_struct_alloc`, `_mvl_array_get`, and every string-creating function returned JS-side handle-table indices, but the compiled module does raw `i64.store`/`i64.load`/`i32.load` directly on those return values (confirmed via WAT inspection of `score_guess`, `for x in [array]` loops, and `s.concat(s)`). A handle used as a raw memory address corrupts real module memory.
- **This is what mvl-lang/mvl#2083 actually was.** `actor_trading` calls `_mvl_struct_alloc` 18 times — this harness ran that test against a broken allocator the whole time the crash was filed as a compiler bug. After the fix: no crash, full run, output values match native exactly. Closed #2083 with a correcting comment.
- Also documented a genuine (non-bug) backend difference: native actor output ordering is nondeterministic across runs; WASM's is deterministic.

## Changes

### Fixed
- `_mvl_struct_alloc`/`_mvl_array_get` now use a real bump allocator into shared linear memory instead of a handle table.
- String-creating functions (`_mvl_string_new/concat/substring/to_upper/to_lower/trim/replace`) now write UTF-8 bytes + a `{ptr,len}` descriptor into the same scratch space instead of a Map handle.

### Documented
- README: full writeup of the bug, the corrected #2083, and the actor-ordering finding.

## Testing

- [x] `./run-tests.sh` — no crash, no runtime error; `option_probe` still PASS (no regression on the earlier Option/Result fix); `actor_trading` FAILs only on documented ordering, values match native exactly
- [x] 3x repeated native `mvl run` vs 3x repeated WASM run — native varies (2 distinct md5s / 3 runs), WASM is stable (1 md5 / 3 runs)
- [x] mvl-lang/mvl#2083 closed with correcting comment

No CI configured in this repo, merging directly once reviewed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>