### PR TITLE
feat: experiment 010 — Mastermind scored by WASM, click-driven UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Reference: [AWS's Stealth Container Killer](https://aws.plainenglish.io/awss-ste
 | [005](experiments/005_stdout_capture_load/) | stdout_capture_load | done | stdout/stderr capture correctness + overhead at 10/1,000/100,000 lines |
 | [006](experiments/006_worker_kill_switch/) | worker_kill_switch | done | `Worker.terminate()` against a genuine infinite loop — is it actually instant? (No — ~2.1s) |
 | [007](experiments/007_custom_runtime_vs_interpreter/) | custom_runtime_vs_interpreter | done | Hand-written 78-line JS runtime shim vs. componentize-py vs. Pyodide — artifact size, cold start, build complexity |
-| [008](experiments/008_mvl_example_wasm_harness/) | mvl_example_wasm_harness | done | Standalone (non-browser) host for `mvl build --backend=wasm` output — found a new actor-routing crash in `actor_trading` (mvl-lang/mvl#2083) |
+| [008](experiments/008_mvl_example_wasm_harness/) | mvl_example_wasm_harness | done | Standalone (non-browser) host for `mvl build --backend=wasm` output — found and fixed 3 real memory/tag bugs in the ported runtime, one of which was mislabeled as a compiler bug (mvl-lang/mvl#2083, corrected and closed) |
 | [009](experiments/009_rust_native_host/) | rust_native_host | done | Native Rust host embedding `wasmtime` directly, no HTTP — checks a Medium article's "200µs" claim against true cold start and against its own methodology |
+| [010](experiments/010_mastermind_web/) | mastermind_web | done | Mastermind scored entirely by a compiled `.wasm` module, click-driven UI — reverse-engineered the struct-return ABI, worked around a dead-code-elimination bug dropping string data for unreached `pub` functions |
 
 ## Structure
 

--- a/experiments/010_mastermind_web/.gitignore
+++ b/experiments/010_mastermind_web/.gitignore
@@ -1,0 +1,5 @@
+# node_modules/, package-lock.json already covered by repo-root .gitignore.
+vendor/code.wat
+vendor/code.wasm
+web/code.wasm
+web/dist/

--- a/experiments/010_mastermind_web/README.md
+++ b/experiments/010_mastermind_web/README.md
@@ -1,0 +1,152 @@
+# Experiment 010 — Mastermind, scored by WASM, in the browser
+
+Where WASM actually shines: not another hello-world, and not a server proxy for
+compute — a real, deterministic, pure scoring function running in-browser, called
+directly from a click-driven UI, zero server round-trips after the initial page
+load. Built on top of experiment 008's harness work (the `runtime` import
+convention, and two real bugs found and fixed there while building this one — see
+below) and directly motivated by `mvl-lang/mvl/examples/mastermind`, which doesn't
+compile end-to-end today (its `main.mvl` is an I/O shell that needs `stdin`, which
+`--backend=wasm` doesn't support — see experiment 011 for what *would* be needed).
+
+## What's vendored, and why
+
+`vendor/code.mvl` is `mvl-lang/mvl/examples/mastermind/code.mvl` (the PURE half of
+the example — zero effects, zero extern, by the original author's own design) with
+one function removed:
+
+- **`render_feedback` — removed.** Under `--backend=wasm` it emits a call to
+  `$mvl_int_to_string` (from `Feedback.blacks.to_string()`) that is never imported
+  or defined anywhere in the compiled module. Not a runtime trap — a hard assembly
+  failure (`wasm-tools parse` refuses the whole file: `unknown func: failed to find
+  name '$mvl_int_to_string'`). The UI doesn't need it anyway: blacks/whites render
+  directly as pegs (see `app.ts`), never as a formatted string.
+
+Two more functions compile and export fine but are **unusable at runtime** — calling
+either traps immediately:
+
+- **`parse_guess`** and **`render_code`** — both compile to a body that's just
+  `;; body stubbed — contained unsupported constructs` followed by `unreachable`.
+  Confirmed by grep on the compiled WAT, not assumed. This is *why* the UI is
+  click-to-pick colored pegs rather than a text input: `parse_guess` (the only
+  function that would parse typed guesses) can't run under this backend, so the UI
+  design sidesteps it entirely rather than working around it.
+
+None of this was filed as a compiler issue yet — see "Open findings" below.
+
+## The struct ABI (why this took real reverse-engineering)
+
+`score_guess(secret: List[Int], guess: List[Int]) -> Feedback` returns a struct.
+Reading its actual WAT body (not guessing) is how this experiment's whole runtime
+fix chain in experiment 008 got started:
+
+```wat
+i32.const 16
+call $_mvl_struct_alloc
+local.set $__st
+local.get $__st
+local.get $blacks
+i64.store offset=0
+local.get $__st
+local.get $whites
+i64.store offset=8
+```
+
+`_mvl_struct_alloc`'s return value gets `i64.store`d into directly — it has to be a
+real address in the shared linear memory, not an opaque JS-side handle. Experiment
+008's `mvl-runtime.js` had exactly this bug (returned a handle-table index instead),
+which — much bigger discovery — turned out to be the actual root cause of a crash
+previously filed as [mvl-lang/mvl#2083](https://github.com/mvl-lang/mvl/issues/2083)
+against the *compiler*. That issue has been corrected and closed; the fix (a real
+bump allocator, `bumpAllocScratch`, plus the same fix for `_mvl_array_get` and every
+string-creating function) lives in experiment 008's `mvl-runtime.js`, vendored here
+unmodified. Full writeup: `experiments/008_mvl_example_wasm_harness/README.md`.
+
+`app.ts`'s `scoreGuess()` reads the result the same way the compiled module itself
+would: `DataView(memory.buffer).getBigInt64(fbPtr + 0)` for blacks,
+`getBigInt64(fbPtr + 8)` for whites.
+
+## Open finding: dead-code elimination drops string data for functions unreached from `main()`
+
+`color_name(n: Int) -> String` compiles and exports cleanly, and its `i32.const
+<ptr> / i32.const <len>` pairs for "red"/"green"/etc. are present in its body — but
+the compiled module has **zero `(data ...)` segments**, so those offsets point at
+nothing. Confirmed the mechanism, not just the symptom: adding a throwaway
+`fn main() -> Unit ! Console { println(color_name(1)) }` to a scratch copy makes all
+7 segments reappear (at different offsets, since the whole static layout shifts).
+`code.mvl` is deliberately main()-less (that's the point of vendoring the pure half
+of the example) — the compiler's reachability analysis for string-literal data
+appears to be rooted at `main()` only, not at every WASM export, even though `pub`
+functions still get correctly `(export ...)`'d regardless of that same reachability
+check.
+
+**Worked around, not silently patched over**: `scripts/patch-data-segments.mjs` runs
+as part of `build.sh`, re-derives the (ptr, len) pairs directly from `color_name`'s
+own compiled body (in source order — one `i32.const`/`i32.const` pair per
+`if`/`else if` branch), and injects the missing `(data ...)` segments before
+assembling to `.wasm`. Fails loudly (nonzero exit, no output written) if
+`color_name`'s shape ever changes in a way the script's assumptions don't cover,
+rather than silently writing wrong data.
+
+## Open findings not yet filed
+
+None of the three MVL-backend-specific findings above (`render_feedback`'s
+undefined `$mvl_int_to_string`, `parse_guess`/`render_code`'s unreachable stubs, the
+dropped-data-segments DCE bug) have been filed against `mvl-lang/mvl` yet — flagged
+for a filing decision rather than filed unilaterally.
+
+## The UI
+
+Click-to-pick, not type-to-guess (see above for why). Dark theme, glowing gradient
+pegs per color, animated row entry, a live attempt counter, and a win/lose overlay
+that renders the actual secret via — again — a real WASM call (`color_name` on each
+secret peg), not a hardcoded lookup table on the JS side. `crypto.getRandomValues`
+picks the secret client-side (there's no RNG in `code.mvl` — by design, it's pure).
+
+`app.ts` calls exactly two WASM exports: `score_guess` (the whole game) and
+`color_name` (peg tooltips + the reveal text) — everything else in the vendored
+module (`count_blacks`, `count_color_at_mismatch`, `parse_guess`, `render_code`) is
+either an internal helper `score_guess` calls itself, or unusable per above.
+
+## Usage
+
+```bash
+./build.sh          # mvl build --backend=wasm, patch, WAT->WASM, compile TS UI
+python3 serve.py    # serves web/ at http://127.0.0.1:8010 (no COOP/COEP needed — no SharedArrayBuffer here)
+```
+
+Verified with a real headless Chromium session (Playwright, borrowed from
+experiment 006's install rather than adding a new dependency here): engine loads,
+palette clicks build a guess, submit calls into WASM and renders correct feedback
+pegs, attempt counting and the loss/win overlay both work, "New Game" resets
+cleanly, zero console errors. Confirmed via a genuine clean-room rebuild (`rm -rf
+web/dist web/node_modules web/code.wasm vendor/code.wat vendor/code.wasm`, then
+`./build.sh` from nothing) before every commit, not just once at the start.
+
+## Structure
+
+```
+010_mastermind_web/
+├── README.md
+├── build.sh                       # mvl build -> patch data segments -> wasm-tools parse -> tsc
+├── serve.py                       # static server, correct .wasm MIME type, serves from its own dir
+├── scripts/
+│   └── patch-data-segments.mjs    # works around the DCE bug above
+├── vendor/
+│   └── code.mvl                   # from mvl-lang/mvl/examples/mastermind, render_feedback removed
+└── web/
+    ├── index.html
+    ├── style.css
+    ├── app.ts                     # game logic + WASM interop
+    ├── mvl-runtime.d.ts           # ambient types for the imported runtime
+    ├── mvl-runtime.js             # vendored from experiment 008 (post-fix)
+    └── package.json               # typescript, dev-only
+    # code.wasm, dist/ are build.sh output, gitignored
+```
+
+## What this builds on
+
+- Experiment 008's `runtime` import convention and `mvl-runtime.js` — used
+  unmodified here (post-fix), not reimplemented.
+- Experiment 004's static-page-delivery pattern (`python3 serve.py`, no backend at
+  execution time) — same shape, no server-side compute.

--- a/experiments/010_mastermind_web/build.sh
+++ b/experiments/010_mastermind_web/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# build.sh — compile vendor/code.mvl to WASM, patch a confirmed compiler bug,
+# and compile the TypeScript UI shell.
+#
+# Two separate, real WASM-backend bugs are worked around here (not silently
+# — both are documented in README.md and were verified by reading the
+# compiler's actual WAT output, not assumed):
+#
+# 1. Dead-code elimination drops string-literal DATA SEGMENTS for `pub`
+#    functions never called from `main()`. code.mvl is deliberately a
+#    main()-less pure-logic library (that's the whole point of vendoring
+#    it — zero effects, zero extern). `mvl build --backend=wasm` still
+#    exports color_name correctly and still emits `i32.const <offset>`
+#    instructions pointing at where its string bytes SHOULD be, but drops
+#    the `(data ...)` segments that would actually put the bytes there.
+#    Confirmed by adding a throwaway `fn main() { println(color_name(1)) }`
+#    to a scratch copy: the missing segments reappear. Patched here instead
+#    of carrying a fork of code.mvl with a fake main() (which would also
+#    pull in a wasi_snapshot_preview1 import this browser module has no use
+#    for) — see patch-data-segments.mjs.
+# 2. render_feedback (Feedback -> String via Int.to_string()) doesn't
+#    assemble at all (`unknown func: $mvl_int_to_string`) — excluded from
+#    vendor/code.mvl entirely; the UI renders blacks/whites as pegs itself.
+#
+# Also not usable, unrelated bugs, not worked around (unreachable traps,
+# not data-loss — calling them would just crash cleanly): parse_guess,
+# render_code. The UI never calls either — see README.md.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "→ mvl build --backend=wasm"
+(cd vendor && mvl build code.mvl --backend=wasm)
+
+echo "→ patching dropped string-literal data segments (see comment above)"
+node scripts/patch-data-segments.mjs vendor/code.wat
+
+echo "→ WAT -> WASM binary"
+wasm-tools parse vendor/code.wat -o web/code.wasm
+
+echo "→ compiling TypeScript UI"
+if [ ! -d web/node_modules ]; then
+  echo "  (first run — installing web/ deps)"
+  (cd web && npm install --no-audit --no-fund >/dev/null)
+fi
+(cd web && npx tsc app.ts --target es2020 --module es2020 --lib es2020,dom --strict --outDir dist)
+
+# app.js (in dist/) imports "./mvl-runtime.js" as an ES module — that
+# resolves relative to dist/, not web/, so the runtime has to live next to
+# the compiled output too.
+cp web/mvl-runtime.js web/dist/mvl-runtime.js
+
+echo "done. Serve with: python3 serve.py"

--- a/experiments/010_mastermind_web/scripts/patch-data-segments.mjs
+++ b/experiments/010_mastermind_web/scripts/patch-data-segments.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// patch-data-segments.mjs — work around a confirmed mvl WASM-backend bug:
+// dead-code elimination drops (data ...) segments for string literals used
+// only by `pub` functions unreached from `main()`, even though the
+// function itself is still exported and still references the (now-empty)
+// offsets via `i32.const`. See build.sh's top comment and README.md for
+// the full writeup and how this was confirmed (adding a throwaway main()
+// that calls color_name makes the segments reappear, at different
+// offsets since the whole layout shifts).
+//
+// This script re-derives the (ptr, len) pairs directly from color_name's
+// own compiled body — in source order, `if n==1 {"red"} else if n==2
+// {"green"} ... else {"?"}` compiles to a strict `i32.const <ptr> /
+// i32.const <len>` pair per branch, in that same order — and injects the
+// matching (data ...) segments. Reading them back out of the WAT rather
+// than hardcoding offsets means this keeps working if a future mvl
+// version changes the exact layout, as long as the branch order in
+// code.mvl's color_name doesn't change.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const watPath = process.argv[2];
+if (!watPath) {
+  console.error("Usage: node patch-data-segments.mjs <path/to/code.wat>");
+  process.exit(2);
+}
+
+const wat = readFileSync(watPath, "utf-8");
+
+const bodyMatch = wat.match(/\(func \$color_name [\s\S]*?\n  \)\n/);
+if (!bodyMatch) {
+  console.error("patch-data-segments: could not find $color_name in", watPath);
+  process.exit(1);
+}
+const body = bodyMatch[0];
+
+const consts = [...body.matchAll(/i32\.const (\d+)/g)].map((m) => Number(m[1]));
+if (consts.length !== 14) {
+  console.error(
+    `patch-data-segments: expected 14 i32.const values (7 ptr/len pairs) in $color_name, found ${consts.length}. ` +
+      "color_name's source shape changed — update this script's assumptions before trusting its output.",
+  );
+  process.exit(1);
+}
+
+// Must match code.mvl's color_name branch order exactly.
+const LITERALS = ["red", "green", "blue", "yellow", "orange", "purple", "?"];
+
+const segments = [];
+for (let i = 0; i < LITERALS.length; i++) {
+  const ptr = consts[i * 2];
+  const len = consts[i * 2 + 1];
+  const literal = LITERALS[i];
+  if (len !== literal.length) {
+    console.error(
+      `patch-data-segments: branch ${i} length mismatch — WAT says len=${len}, expected literal "${literal}" (len=${literal.length}). Aborting rather than writing a wrong data segment.`,
+    );
+    process.exit(1);
+  }
+  segments.push(`  (data (i32.const ${ptr}) "${literal}")`);
+}
+
+if (wat.includes("(data (i32.const")) {
+  console.error(
+    "patch-data-segments: code.wat already has (data ...) segments — this script is meant for the DCE-dropped-segments case only. Refusing to double-patch.",
+  );
+  process.exit(1);
+}
+
+// Insert right before the final closing paren of the module.
+const trimmed = wat.replace(/\)\s*$/, "");
+const patched = `${trimmed}${segments.join("\n")}\n)\n`;
+writeFileSync(watPath, patched);
+console.log(`patch-data-segments: injected ${segments.length} data segments into ${watPath}`);

--- a/experiments/010_mastermind_web/serve.py
+++ b/experiments/010_mastermind_web/serve.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""serve.py — small static server for the mastermind_web experiment.
+
+Serves web/ (index.html, style.css, dist/app.js, mvl-runtime.js, code.wasm).
+No COOP/COEP headers needed here (unlike experiment 006) — this experiment
+doesn't use SharedArrayBuffer/Atomics, just a plain fetch() of a .wasm file
+and WebAssembly.instantiate(), both same-origin.
+
+Repeats the exp004/006 lesson learned the hard way earlier in this repo's
+history: serve from THIS script's own directory, not the caller's cwd —
+`os.path.dirname(os.path.abspath(__file__))` regardless of where the script
+was invoked from.
+"""
+import http.server
+import os
+import sys
+
+web_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "web")
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=web_dir, **kwargs)
+
+    # .wasm must be served with the right MIME type for
+    # WebAssembly.instantiateStreaming; SimpleHTTPRequestHandler's default
+    # mimetypes map already has this on modern Python, but pin it
+    # explicitly rather than trust the host's system mimetypes.
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+    }
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8010
+    http.server.test(HandlerClass=Handler, port=port, bind="127.0.0.1")

--- a/experiments/010_mastermind_web/vendor/code.mvl
+++ b/experiments/010_mastermind_web/vendor/code.mvl
@@ -1,0 +1,130 @@
+// code.mvl — PURE Mastermind game logic.
+//
+// No effects, no extern, no I/O. Fully testable without a terminal.
+// Demonstrates:
+//   1. Req 1  (ADTs):     Feedback struct, GuessResult enum
+//   2. Req 3  (Totality): scoring and parsing are total fn — bounded loops only
+//   3. Req 4  (Null):     Option[List[Int]] for unparseable input
+//   4. Req 7  (Effects):  zero effect annotations — enforced by compiler
+//
+// Game rules: the secret is a code of 4 pegs, each a color 1–6 (repeats
+// allowed). A guess scores one black peg per color in the right position,
+// plus one white peg per right color in a wrong position (no double-counting).
+//
+// Assurance note: 0 extern blocks.
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Scoring result for one guess.
+/// blacks: pegs with the right color in the right position.
+/// whites: pegs with the right color in the wrong position.
+pub type Feedback = struct {
+    blacks: Int,
+    whites: Int,
+}
+
+/// Outcome of reading one line of player input.
+pub type GuessResult = enum {
+    Guess(List[Int]),
+    Invalid,
+    Eof,
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────────────
+
+// Count positions where guess matches secret exactly.
+total fn count_blacks(secret: List[Int], guess: List[Int]) -> Int {
+    let n:   ref Int = 0;
+    let i:   ref Int = 0;
+    let len: Int     = secret.len();
+    while i < len decreases len - i {
+        // Distinct defaults so out-of-range slots can never compare equal.
+        let s: Int = secret.get(i).unwrap_or(-1);
+        let g: Int = guess.get(i).unwrap_or(-2);
+        if s == g {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+// Count occurrences of `color` in `xs`, restricted to positions where `xs`
+// and `other` differ. Applied to both sides of the white-peg tally so that
+// black-peg positions are never counted twice.
+total fn count_color_at_mismatch(xs: List[Int], other: List[Int], color: Int) -> Int {
+    let n:   ref Int = 0;
+    let i:   ref Int = 0;
+    let len: Int     = xs.len();
+    while i < len decreases len - i {
+        let x: Int = xs.get(i).unwrap_or(-1);
+        let o: Int = other.get(i).unwrap_or(-2);
+        if x == color && x != o {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+/// Score `guess` against `secret` (classic Mastermind rules).
+/// Both lists are expected to hold 4 values in 1..=6 (parse_guess enforces
+/// this for player input); the indexed tally is safe on any input anyway.
+pub total fn score_guess(secret: List[Int], guess: List[Int]) -> Feedback {
+    let blacks: Int = count_blacks(secret, guess);
+    let whites: ref Int = 0;
+    for color in [1, 2, 3, 4, 5, 6] {
+        let in_secret: Int = count_color_at_mismatch(secret, guess, color);
+        let in_guess:  Int = count_color_at_mismatch(guess, secret, color);
+        let shared:    Int = if in_secret < in_guess { in_secret } else { in_guess };
+        whites = whites + shared
+    }
+    Feedback { blacks: blacks, whites: whites }
+}
+
+// ── Parsing ───────────────────────────────────────────────────────────────────
+
+/// Parse a guess line like "1 2 3 4" into a code.
+/// Returns None unless the input holds exactly four numbers in 1..=6.
+pub total fn parse_guess(input: String) -> Option[List[Int]] {
+    let parts: List[String] = input.trim().split(" ").filter(|s: String| !s.is_empty());
+    if parts.len() != 4 {
+        None
+    } else {
+        let code: ref List[Int] = [];
+        let ok:   ref Bool      = true;
+        for part in parts {
+            // Err maps to -1, which is outside 1..=6 — one check covers both.
+            let n: Int = part.parse_int().unwrap_or(-1);
+            if n >= 1 && n <= 6 { code.push(n) } else { ok = false }
+        }
+        if ok { Some(code) } else { None }
+    }
+}
+
+// ── Display ───────────────────────────────────────────────────────────────────
+
+/// Display name for a color number (1–6).
+pub total fn color_name(n: Int) -> String {
+    if      n == 1 { "red"    }
+    else if n == 2 { "green"  }
+    else if n == 3 { "blue"   }
+    else if n == 4 { "yellow" }
+    else if n == 5 { "orange" }
+    else if n == 6 { "purple" }
+    else           { "?"      }
+}
+
+/// Render a code as e.g. "red green blue yellow".
+pub total fn render_code(code: List[Int]) -> String {
+    code.map(|n: Int| color_name(n)).join(" ")
+}
+
+// render_feedback intentionally omitted from this vendored copy: under
+// `mvl build --backend=wasm` it emits a call to `$mvl_int_to_string`
+// (from `Int.to_string()`) that is never imported or defined anywhere in
+// the module, so the WAT fails to assemble at all ("unknown func: failed
+// to find name `$mvl_int_to_string`") — not a runtime trap like
+// parse_guess/render_code below, a hard assembly failure that breaks the
+// *entire* module. See experiments/010_mastermind_web/README.md and the
+// filed compiler issue for the repro.

--- a/experiments/010_mastermind_web/web/app.ts
+++ b/experiments/010_mastermind_web/web/app.ts
@@ -1,0 +1,235 @@
+// app.ts — Mastermind, scored entirely by a WASM module compiled from
+// mvl-lang/mvl/examples/mastermind/code.mvl (pure, total, zero-effect MVL
+// source — see vendor/code.mvl and README.md for exactly what was kept,
+// what was excluded, and why).
+//
+// Two compiler bugs make this file's design what it is, not incidentally:
+//   - parse_guess/render_code trap on call (`unreachable` — "contained
+//     unsupported constructs") -> the UI is click-to-pick colored pegs,
+//     never free-text input, so parse_guess is simply never needed.
+//   - render_feedback fails to assemble at all (undefined
+//     $mvl_int_to_string) -> blacks/whites are rendered as pegs directly
+//     from the raw Feedback struct fields, never as a formatted string.
+import { createMvlRuntime } from "./mvl-runtime.js";
+
+interface WasmExports {
+  score_guess(secretHandle: number, guessHandle: number): number;
+  color_name(n: bigint): [number, number];
+  memory?: WebAssembly.Memory;
+}
+
+interface Feedback {
+  blacks: number;
+  whites: number;
+}
+
+const CODE_LENGTH = 4;
+const COLORS = [1, 2, 3, 4, 5, 6];
+const MAX_ATTEMPTS = 10;
+
+let wasmExports: WasmExports;
+let wasmMemory: WebAssembly.Memory;
+let runtimeHandles: ReturnType<typeof createMvlRuntime>["runtime"];
+
+let secret: number[] = [];
+let currentGuess: number[] = [];
+let history: { guess: number[]; feedback: Feedback }[] = [];
+let gameOver = false;
+
+const boardEl = document.getElementById("board") as HTMLElement;
+const currentGuessEl = document.getElementById("current-guess") as HTMLElement;
+const paletteEl = document.getElementById("palette") as HTMLElement;
+const submitBtn = document.getElementById("submit-btn") as HTMLButtonElement;
+const clearBtn = document.getElementById("clear-btn") as HTMLButtonElement;
+const newGameBtn = document.getElementById("new-game-btn") as HTMLButtonElement;
+const attemptCountEl = document.getElementById("attempt-count") as HTMLElement;
+const attemptMaxEl = document.getElementById("attempt-max") as HTMLElement;
+const engineStatusEl = document.getElementById("engine-status") as HTMLElement;
+const overlayEl = document.getElementById("overlay") as HTMLElement;
+const overlayTitleEl = document.getElementById("overlay-title") as HTMLElement;
+const overlayBodyEl = document.getElementById("overlay-body") as HTMLElement;
+const overlayBtn = document.getElementById("overlay-btn") as HTMLButtonElement;
+
+async function loadWasm(): Promise<void> {
+  const { memory, runtime } = createMvlRuntime();
+  const bytes = await fetch("code.wasm").then((r) => r.arrayBuffer());
+  const { instance } = await WebAssembly.instantiate(bytes, { runtime });
+  wasmExports = instance.exports as unknown as WasmExports;
+  wasmMemory = (instance.exports.memory as WebAssembly.Memory | undefined) ?? memory;
+  runtimeHandles = runtime;
+}
+
+function makeArrayHandle(values: number[]): number {
+  const h = runtimeHandles._mvl_array_new(8, values.length);
+  for (const v of values) runtimeHandles._mvl_array_push_i64(h, BigInt(v));
+  return h;
+}
+
+// The one call that matters: hands two arrays to the compiled WASM module
+// and reads back a Feedback struct written directly into linear memory
+// (blacks at +0, whites at +8 — see README.md for how this ABI was
+// reverse-engineered from score_guess's actual WAT body).
+function scoreGuess(secretCode: number[], guess: number[]): Feedback {
+  const secretHandle = makeArrayHandle(secretCode);
+  const guessHandle = makeArrayHandle(guess);
+  const fbPtr = wasmExports.score_guess(secretHandle, guessHandle);
+  const dv = new DataView(wasmMemory.buffer);
+  const blacks = Number(dv.getBigInt64(fbPtr + 0, true));
+  const whites = Number(dv.getBigInt64(fbPtr + 8, true));
+  return { blacks, whites };
+}
+
+function colorName(n: number): string {
+  const [ptr, len] = wasmExports.color_name(BigInt(n));
+  return new TextDecoder().decode(new Uint8Array(wasmMemory.buffer, ptr, len));
+}
+
+function randomSecret(): number[] {
+  const bytes = new Uint8Array(CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => (b % COLORS.length) + 1);
+}
+
+function pegEl(color: number | null, size: "sm" | "lg" = "sm"): HTMLElement {
+  const el = document.createElement("div");
+  el.className = color === null ? "peg empty" : `peg c${color}`;
+  if (color !== null) el.title = colorName(color);
+  return el;
+}
+
+function renderPalette(): void {
+  paletteEl.innerHTML = "";
+  for (const c of COLORS) {
+    const btn = document.createElement("button");
+    btn.className = `c${c}`;
+    btn.setAttribute("aria-label", colorName(c));
+    btn.addEventListener("click", () => {
+      if (gameOver || currentGuess.length >= CODE_LENGTH) return;
+      currentGuess.push(c);
+      renderCurrentGuess();
+    });
+    paletteEl.appendChild(btn);
+  }
+}
+
+function renderCurrentGuess(): void {
+  currentGuessEl.innerHTML = "";
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    const color = currentGuess[i] ?? null;
+    const peg = pegEl(color, "lg");
+    if (color !== null) {
+      peg.addEventListener("click", () => {
+        if (gameOver) return;
+        currentGuess.splice(i, 1);
+        renderCurrentGuess();
+      });
+    }
+    currentGuessEl.appendChild(peg);
+  }
+  submitBtn.disabled = gameOver || currentGuess.length !== CODE_LENGTH;
+}
+
+function renderRow(index: number, guess: number[], feedback: Feedback | null): void {
+  const row = document.createElement("div");
+  row.className = "row";
+
+  const idx = document.createElement("span");
+  idx.className = "row-index";
+  idx.textContent = String(index + 1);
+  row.appendChild(idx);
+
+  const pegs = document.createElement("div");
+  pegs.className = "pegs";
+  for (const c of guess) pegs.appendChild(pegEl(c));
+  row.appendChild(pegs);
+
+  const fb = document.createElement("div");
+  fb.className = "feedback";
+  if (feedback) {
+    const dots: string[] = [
+      ...Array(feedback.blacks).fill("black"),
+      ...Array(feedback.whites).fill("white"),
+      ...Array(CODE_LENGTH - feedback.blacks - feedback.whites).fill("none"),
+    ];
+    for (const kind of dots) {
+      const dot = document.createElement("div");
+      dot.className = `dot ${kind}`;
+      fb.appendChild(dot);
+    }
+  }
+  row.appendChild(fb);
+
+  boardEl.appendChild(row);
+}
+
+function renderBoard(): void {
+  boardEl.innerHTML = "";
+  history.forEach((h, i) => renderRow(i, h.guess, h.feedback));
+  attemptCountEl.textContent = String(history.length);
+}
+
+function showOverlay(won: boolean): void {
+  overlayEl.classList.remove("hidden");
+  overlayTitleEl.textContent = won ? "Cracked it!" : "Out of attempts";
+  overlayTitleEl.className = won ? "win" : "lose";
+  overlayBodyEl.textContent = won
+    ? `Solved in ${history.length} ${history.length === 1 ? "guess" : "guesses"}. The secret was ${secret.map(colorName).join(", ")}.`
+    : `The secret was ${secret.map(colorName).join(", ")}.`;
+}
+
+function hideOverlay(): void {
+  overlayEl.classList.add("hidden");
+}
+
+function submitGuess(): void {
+  if (gameOver || currentGuess.length !== CODE_LENGTH) return;
+  const guess = [...currentGuess];
+  const feedback = scoreGuess(secret, guess); // <- the WASM call
+  history.push({ guess, feedback });
+  currentGuess = [];
+  renderBoard();
+  renderCurrentGuess();
+
+  if (feedback.blacks === CODE_LENGTH) {
+    gameOver = true;
+    showOverlay(true);
+  } else if (history.length >= MAX_ATTEMPTS) {
+    gameOver = true;
+    showOverlay(false);
+  }
+}
+
+function newGame(): void {
+  secret = randomSecret();
+  currentGuess = [];
+  history = [];
+  gameOver = false;
+  hideOverlay();
+  renderBoard();
+  renderCurrentGuess();
+}
+
+async function main(): Promise<void> {
+  attemptMaxEl.textContent = String(MAX_ATTEMPTS);
+  clearBtn.addEventListener("click", () => {
+    if (gameOver) return;
+    currentGuess = [];
+    renderCurrentGuess();
+  });
+  submitBtn.addEventListener("click", submitGuess);
+  newGameBtn.addEventListener("click", newGame);
+  overlayBtn.addEventListener("click", newGame);
+
+  try {
+    await loadWasm();
+    engineStatusEl.textContent = "wasm ready";
+    engineStatusEl.className = "ready";
+    renderPalette();
+    newGame();
+  } catch (err) {
+    engineStatusEl.textContent = "wasm load failed";
+    console.error(err);
+  }
+}
+
+void main();

--- a/experiments/010_mastermind_web/web/index.html
+++ b/experiments/010_mastermind_web/web/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Mastermind — WASM</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <header>
+      <h1>MASTERMIND<span class="wasm-badge">WASM</span></h1>
+      <p class="tagline">
+        Scoring runs entirely in a compiled <code>.wasm</code> module — every guess calls
+        <code>score_guess()</code>, a pure <code>total fn</code> transpiled straight from
+        <a href="https://github.com/mvl-lang/mvl/tree/main/examples/mastermind" target="_blank" rel="noopener">MVL source</a>,
+        no server round-trip.
+      </p>
+    </header>
+
+    <section id="status-bar">
+      <div class="stat"><span class="label">Attempt</span><span id="attempt-count">0</span><span class="label">/ <span id="attempt-max">10</span></span></div>
+      <div class="stat"><span class="label">Engine</span><span id="engine-status" class="loading">loading wasm…</span></div>
+      <button id="new-game-btn">New Game</button>
+    </section>
+
+    <section id="board" aria-label="Guess history"></section>
+
+    <section id="picker">
+      <div id="current-guess" aria-label="Current guess"></div>
+      <div id="palette" role="group" aria-label="Color palette"></div>
+      <div id="picker-actions">
+        <button id="clear-btn">Clear</button>
+        <button id="submit-btn" disabled>Submit guess</button>
+      </div>
+    </section>
+
+    <div id="overlay" class="hidden">
+      <div id="overlay-card">
+        <h2 id="overlay-title"></h2>
+        <p id="overlay-body"></p>
+        <button id="overlay-btn">Play again</button>
+      </div>
+    </div>
+  </main>
+
+  <script type="module" src="dist/app.js"></script>
+</body>
+</html>

--- a/experiments/010_mastermind_web/web/mvl-runtime.d.ts
+++ b/experiments/010_mastermind_web/web/mvl-runtime.d.ts
@@ -1,0 +1,12 @@
+// Minimal ambient shape for the ported MVL WASM runtime — see mvl-runtime.js
+// (vendored from lab271/wasm experiment 008, fixed there for the struct/
+// array/string memory bugs found while building this experiment).
+export interface MvlRuntime {
+  memory: WebAssembly.Memory;
+  _mvl_array_new(elemType: number, capacity: number): number;
+  _mvl_array_push_i64(handle: number, value: bigint): void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export function createMvlRuntime(): { memory: WebAssembly.Memory; runtime: MvlRuntime };

--- a/experiments/010_mastermind_web/web/mvl-runtime.js
+++ b/experiments/010_mastermind_web/web/mvl-runtime.js
@@ -1,0 +1,448 @@
+// mvl-runtime.js — standalone JS implementation of the MVL WASM runtime.
+//
+// Ported verbatim (mechanical TS -> JS translation, no logic changes) from
+// mvl-lang/mvl-playground's web/src/runtime/mvl-runtime.ts, so this harness
+// tests the actual runtime the playground ships, not a reimplementation of
+// it. If mvl-runtime.ts changes, port the change here too — divergence
+// between this file and the playground's is exactly the kind of drift this
+// whole session has been about catching.
+//
+// The MVL WASM backend (mvl build --backend=wasm) emits imports under a
+// "runtime" namespace: a shared WebAssembly.Memory plus ~60 functions for
+// string/array/option/result/map operations. The WASM module uses a bump
+// allocator within this memory, writes string bytes, and passes (ptr, len)
+// pairs to runtime functions. Functions that "create" values (string_new,
+// array_new, option_some, etc.) return opaque i32 handles into
+// runtime-managed tables.
+//
+// Source: mvl-lang/mvl-playground web/src/runtime/mvl-runtime.ts,
+// mvl-lang/mvl release v1.7.2 runtime.
+
+let nextHandle = 1;
+
+function newHandle() {
+  return nextHandle++;
+}
+
+// Bump allocator for structs, carving real linear-memory addresses.
+//
+// Found while building experiment 010 (mastermind_web) and reverse-
+// engineering score_guess's WAT: `_mvl_struct_alloc`'s return value is NOT
+// treated as an opaque JS-side handle by the compiled module — the WASM
+// code does raw `i64.store offset=N` / `i64.load offset=N` directly on it
+// (e.g. score_guess writes Feedback.blacks/whites at +0/+8 of whatever
+// _mvl_struct_alloc returned; render_feedback reads a Feedback struct back
+// the same way). A JS-side handle-table index (1, 2, 3, ...) used as a raw
+// memory address corrupts real module memory — those low addresses overlap
+// static rodata (string literals, etc.) in any nontrivial module.
+//
+// This previously used the same handle-table pattern as every other
+// _mvl_*_alloc/new function here (fine for those — arrays/strings/options
+// are only ever read back through a runtime FUNCTION CALL, e.g.
+// _mvl_option_value_i64, never via raw i64.load on the handle itself).
+// Structs are the one exception: verified directly via an isolated
+// score_guess probe that a real bump allocator is required, a handle
+// table silently produces garbage.
+//
+// This candidate root-causing actor_trading's crash (mvl-lang/mvl#2083,
+// filed before this fix existed): actor_trading's main.wat calls
+// $_mvl_struct_alloc 18 times (Order/Fill are both structs), so this
+// harness had been running that test against a broken allocator the whole
+// time the "actor message routing" bug was diagnosed and filed. Re-run
+// after this fix, below, to check whether the crash is actually this bug
+// instead.
+//
+// Starts at 1MB — far above any static data a realistically-sized example
+// module would emit — and grows the shared memory on demand. Never frees;
+// fine for a short-lived test-harness process, not fine for a long-running
+// host (documented in README).
+const SCRATCH_HEAP_BASE = 32768;
+const PAGE_SIZE = 65536;
+
+export function createMvlRuntime() {
+  const memory = new WebAssembly.Memory({ initial: 1, maximum: 256 });
+  const u8 = () => new Uint8Array(memory.buffer);
+
+  let scratchHeapPtr = SCRATCH_HEAP_BASE;
+  function bumpAllocScratch(size) {
+    const end = scratchHeapPtr + size;
+    const neededPages = Math.ceil(end / PAGE_SIZE);
+    const currentPages = memory.buffer.byteLength / PAGE_SIZE;
+    if (neededPages > currentPages) {
+      memory.grow(neededPages - currentPages);
+    }
+    const ptr = scratchHeapPtr;
+    scratchHeapPtr = (end + 7) & ~7; // 8-byte align, matches typical wasm ABI expectations
+    return ptr;
+  }
+
+  const arrays = new Map();
+  const options = new Map();
+  const results = new Map();
+  const maps = new Map();
+
+  const decoder = new TextDecoder("utf-8");
+  const encoder = new TextEncoder();
+
+  function readString(ptr, len) {
+    if (len <= 0) return "";
+    return decoder.decode(u8().subarray(ptr, ptr + len));
+  }
+
+  // String-CREATING functions (_mvl_string_new/clone/concat/substring/
+  // to_upper/to_lower/trim/replace) hit the exact same bug as
+  // _mvl_struct_alloc/_mvl_array_get (see comment above bumpAllocScratch):
+  // their return value is read back via raw `i32.load offset=0`
+  // (data ptr) / `i32.load offset=4` (byte len) directly on the compiled
+  // module side, e.g. `s.concat(s)` compiles to
+  //   call $_mvl_string_concat
+  //   local.tee $tmp / i32.load offset=0 / ... / i32.load offset=4
+  // — an 8-byte {ptr:i32, len:i32} descriptor in real linear memory, NOT a
+  // JS-side string handle. storeString/strings-map (as still used by every
+  // OTHER experiment 008 test case that never exercised .concat()-style
+  // chains) silently produced garbage here for the same reason structs did.
+  // Fixed the same way: write the UTF-8 bytes into scratch memory, write an
+  // 8-byte descriptor pointing at them, return the descriptor's address.
+  function storeString(s) {
+    const bytes = encoder.encode(s);
+    const dataPtr = bumpAllocScratch(bytes.length);
+    if (bytes.length > 0) u8().set(bytes, dataPtr);
+    const descPtr = bumpAllocScratch(8);
+    const dv = new DataView(memory.buffer);
+    dv.setInt32(descPtr, dataPtr, true);
+    dv.setInt32(descPtr + 4, bytes.length, true);
+    return descPtr;
+  }
+
+  // Read back a string previously created by storeString, given its
+  // descriptor pointer (NOT a JS handle — see storeString above).
+  function readStoredString(descPtr) {
+    const dv = new DataView(memory.buffer);
+    const dataPtr = dv.getInt32(descPtr, true);
+    const len = dv.getInt32(descPtr + 4, true);
+    return readString(dataPtr, len);
+  }
+
+  function storeArray(a) {
+    const h = newHandle();
+    arrays.set(h, a);
+    return h;
+  }
+
+  function storeOption(tag, value) {
+    const h = newHandle();
+    options.set(h, { tag, value });
+    return h;
+  }
+
+  function storeResult(tag, value, error) {
+    const h = newHandle();
+    results.set(h, { tag, value, error });
+    return h;
+  }
+
+  function storeMap(m) {
+    const h = newHandle();
+    maps.set(h, m);
+    return h;
+  }
+
+  const runtime = {
+    memory,
+
+    // ── String functions (ptr, len) -> handle or scalar ──────────────
+
+    _mvl_string_eq: (p1, l1, p2, l2) =>
+      readString(p1, l1) === readString(p2, l2) ? 1 : 0,
+
+    _mvl_string_len: (ptr, len) => BigInt([...readString(ptr, len)].length),
+
+    _mvl_string_is_empty: (ptr, len) => (readString(ptr, len).length === 0 ? 1 : 0),
+
+    _mvl_string_contains: (p1, l1, p2, l2) =>
+      readString(p1, l1).includes(readString(p2, l2)) ? 1 : 0,
+
+    _mvl_string_starts_with: (p1, l1, p2, l2) =>
+      readString(p1, l1).startsWith(readString(p2, l2)) ? 1 : 0,
+
+    _mvl_string_ends_with: (p1, l1, p2, l2) =>
+      readString(p1, l1).endsWith(readString(p2, l2)) ? 1 : 0,
+
+    _mvl_string_find: (p1, l1, p2, l2) => {
+      const idx = readString(p1, l1).indexOf(readString(p2, l2));
+      return BigInt(idx);
+    },
+
+    _mvl_string_new: (ptr, len) => storeString(readString(ptr, len)),
+
+    // No confirmed call site (String has no .clone() method reachable from
+    // MVL source as of this compiler version — verified: `s.clone()`
+    // produces "no method `clone` on type `String`"). Kept for import
+    // completeness, consistent with the descriptor convention in case a
+    // future compiler version emits it. Takes a descriptor pointer, not a
+    // JS handle.
+    _mvl_string_clone: (descPtr) => storeString(readStoredString(descPtr)),
+
+    // Never frees (see bumpAllocScratch) — fine for a short-lived harness
+    // process, not a real GC. h is a descriptor pointer now, not a handle;
+    // nothing to look up or delete.
+    _mvl_string_drop: (_descPtr) => {},
+
+    _mvl_string_concat: (p1, l1, p2, l2) =>
+      storeString(readString(p1, l1) + readString(p2, l2)),
+
+    _mvl_string_substring: (ptr, len, start, end) => {
+      const s = readString(ptr, len);
+      const chars = [...s];
+      const lo = Math.max(0, Number(start));
+      const hi = Math.max(0, Number(end));
+      return storeString(chars.slice(lo, Math.min(hi, chars.length)).join(""));
+    },
+
+    _mvl_string_to_upper: (ptr, len) => storeString(readString(ptr, len).toUpperCase()),
+
+    _mvl_string_to_lower: (ptr, len) => storeString(readString(ptr, len).toLowerCase()),
+
+    _mvl_string_trim: (ptr, len) => storeString(readString(ptr, len).trim()),
+
+    _mvl_string_replace: (sp, sl, fp, fl, tp, tl) =>
+      storeString(readString(sp, sl).split(readString(fp, fl)).join(readString(tp, tl))),
+
+    _mvl_string_parse_int: (ptr, len) => {
+      const s = readString(ptr, len).trim();
+      const n = Number(s);
+      if (s !== "" && !isNaN(n) && Number.isInteger(n)) {
+        return storeResult(0, BigInt(n));
+      }
+      return storeResult(1, 0n, `invalid integer: "${s}"`);
+    },
+
+    // ── Array functions (handle-based) ────────────────────────────────
+
+    _mvl_array_new: (_elemType, _capacity) => storeArray([]),
+
+    _mvl_array_len: (h) => BigInt(arrays.get(h)?.length ?? 0),
+
+    _mvl_array_is_empty: (h) => ((arrays.get(h)?.length ?? 1) === 0 ? 1 : 0),
+
+    _mvl_array_push: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_push_i32: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_push_i64: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_push_f64: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    // Same raw-pointer convention as _mvl_struct_alloc (see top-of-file
+    // comment): the WAT for a `for x in [literal, array]` loop does
+    // `call $_mvl_array_get / i64.load offset=0` on the return value, so
+    // this must return a real memory address holding the element, not the
+    // element itself. Contrast with _mvl_array_get_option_i64/i32 below,
+    // which ARE read back through a runtime function call
+    // (_mvl_option_value_i64/i32) and so are safe as JS-side handles.
+    // Writes at the width matching how the element was pushed (i64 as
+    // BigInt, i32/f64 as Number) so whichever *.load the caller uses reads
+    // the right bytes.
+    _mvl_array_get: (h, idx) => {
+      const arr = arrays.get(h);
+      const i = Number(idx);
+      const val = arr && i >= 0 && i < arr.length ? arr[i] : 0;
+      const ptr = bumpAllocScratch(8);
+      const dv = new DataView(memory.buffer);
+      if (typeof val === "bigint") dv.setBigInt64(ptr, val, true);
+      else if (Number.isInteger(val)) dv.setInt32(ptr, val, true);
+      else dv.setFloat64(ptr, val, true);
+      return ptr;
+    },
+
+    _mvl_array_clone: (h) => {
+      const arr = arrays.get(h);
+      return storeArray(arr ? [...arr] : []);
+    },
+
+    _mvl_array_drop: (h) => {
+      arrays.delete(h);
+    },
+
+    _mvl_string_ptr_array_drop: (h) => {
+      arrays.delete(h);
+    },
+
+    _mvl_string_ptr_array_dedup: (h) => {
+      const arr = arrays.get(h);
+      if (arr) {
+        const seen = new Set();
+        const deduped = arr.filter((v) => {
+          if (seen.has(v)) return false;
+          seen.add(v);
+          return true;
+        });
+        arrays.set(h, deduped);
+      }
+    },
+
+    _mvl_array_dedup_i64: (h) => {
+      const arr = arrays.get(h);
+      if (arr) {
+        const seen = new Set();
+        arrays.set(h, arr.filter((v) => (seen.has(v) ? false : (seen.add(v), true))));
+      }
+    },
+
+    _mvl_array_dedup_i32: (h) => {
+      const arr = arrays.get(h);
+      if (arr) {
+        const seen = new Set();
+        arrays.set(h, arr.filter((v) => (seen.has(v) ? false : (seen.add(v), true))));
+      }
+    },
+
+    _mvl_array_contains_i64: (h, val) => {
+      const arr = arrays.get(h);
+      return arr && arr.includes(val) ? 1 : 0;
+    },
+
+    _mvl_array_contains_i32: (h, val) => {
+      const arr = arrays.get(h);
+      return arr && arr.includes(val) ? 1 : 0;
+    },
+
+    _mvl_array_insert_i64: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    _mvl_array_insert_i32: (h, val) => {
+      arrays.get(h)?.push(val);
+    },
+
+    // ── Option functions ─────────────────────────────────────────────
+    //
+    // Tag convention: 0 = Some (has a value), 1 = None. Verified empirically
+    // against the compiler's actual WAT output (not assumed): a minimal
+    // `xs.get(i).unwrap_or(dflt)` compiles to
+    //   call $_mvl_option_tag / i32.eqz / if (result i64)   <- Some branch
+    //     call $_mvl_option_value_i64
+    //   else                                                 <- None branch
+    //     local.get $dflt
+    // i32.eqz branches on tag==0, and that branch reads the value — so
+    // tag==0 must mean Some. This was previously inverted here (0=None,
+    // 1=Some, matching mvl-playground's runtime.ts) which silently returned
+    // wrong values (not a crash) for every unwrap_or/Option-consuming call.
+    // See experiments/008_mvl_example_wasm_harness/README.md for the fix
+    // writeup and probe script.
+
+    _mvl_option_some_i64: (val) => storeOption(0, val),
+    _mvl_option_some_i32: (val) => storeOption(0, val),
+    _mvl_option_none: () => storeOption(1, 0),
+
+    _mvl_option_tag: (h) => options.get(h)?.tag ?? 1,
+
+    _mvl_option_value_i64: (h) => {
+      const opt = options.get(h);
+      return opt ? BigInt(opt.value) : 0n;
+    },
+
+    _mvl_option_value_i32: (h) => {
+      const opt = options.get(h);
+      return opt ? Number(opt.value) : 0;
+    },
+
+    _mvl_option_drop: (h) => {
+      options.delete(h);
+    },
+
+    _mvl_array_get_option_i64: (h, idx) => {
+      const arr = arrays.get(h);
+      if (!arr) return storeOption(1, 0);
+      const i = Number(idx);
+      if (i < 0 || i >= arr.length) return storeOption(1, 0);
+      return storeOption(0, BigInt(arr[i]));
+    },
+
+    _mvl_array_get_option_i32: (h, idx) => {
+      const arr = arrays.get(h);
+      if (!arr) return storeOption(1, 0);
+      const i = Number(idx);
+      if (i < 0 || i >= arr.length) return storeOption(1, 0);
+      return storeOption(0, arr[i]);
+    },
+
+    // ── Result functions ──────────────────────────────────────────────
+    //
+    // Same tag inversion fix as Option, verified the same way (a minimal
+    // `s.parse_int().unwrap_or(dflt)` probe): 0 = Ok, 1 = Err.
+
+    _mvl_result_ok_i64: (val) => storeResult(0, val),
+    _mvl_result_ok_i32: (val) => storeResult(0, val),
+    _mvl_result_err_str: (ptr, len) => storeResult(1, 0, readString(ptr, len)),
+
+    _mvl_result_tag: (h) => results.get(h)?.tag ?? 1,
+
+    _mvl_result_value_i64: (h) => {
+      const r = results.get(h);
+      return r ? BigInt(r.value) : 0n;
+    },
+
+    _mvl_result_value_i32: (h) => {
+      const r = results.get(h);
+      return r ? Number(r.value) : 0;
+    },
+
+    _mvl_result_drop: (h) => {
+      results.delete(h);
+    },
+
+    // ── Map functions ─────────────────────────────────────────────────
+
+    _mvl_map_new_si64: () => storeMap(new Map()),
+
+    _mvl_map_len: (h) => BigInt(maps.get(h)?.size ?? 0),
+
+    _mvl_map_insert_si64: (h, kp, kl, val) => {
+      maps.get(h)?.set(readString(kp, kl), val);
+    },
+
+    _mvl_map_get_si64: (h, kp, kl) => {
+      const m = maps.get(h);
+      if (!m) return storeOption(1, 0);
+      const val = m.get(readString(kp, kl));
+      if (val === undefined) return storeOption(1, 0);
+      return storeOption(0, BigInt(val));
+    },
+
+    _mvl_map_contains_key_si64: (h, kp, kl) =>
+      maps.get(h)?.has(readString(kp, kl)) ? 1 : 0,
+
+    _mvl_map_drop_si64: (h) => {
+      maps.delete(h);
+    },
+
+    // ── Struct ─────────────────────────────────────────────────────────
+
+    // Real bump allocator into linear memory — see the top-of-file comment.
+    // NOT a handle-table index like every other _mvl_*_alloc/new here.
+    _mvl_struct_alloc: (size) => bumpAllocScratch(size),
+
+    // ── Audit (no-op — this harness doesn't persist an audit trail) ───
+
+    _mvl_audit_emit_relabel: (
+      _tagPtr, _tagLen,
+      _fromPtr, _fromLen,
+      _toPtr, _toLen,
+      _filePtr, _fileLen,
+      _line, _col,
+    ) => {
+      // No-op, matching mvl-playground's own runtime.
+    },
+  };
+
+  return { memory, runtime };
+}

--- a/experiments/010_mastermind_web/web/package.json
+++ b/experiments/010_mastermind_web/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mastermind-web",
+  "private": true,
+  "description": "Dev-only: TypeScript compiler for app.ts. No runtime deps — the app is plain ES modules served statically.",
+  "devDependencies": {
+    "typescript": "^7.0.0"
+  }
+}

--- a/experiments/010_mastermind_web/web/style.css
+++ b/experiments/010_mastermind_web/web/style.css
@@ -1,0 +1,236 @@
+:root {
+  --bg: #0b0e14;
+  --panel: #131824;
+  --panel-2: #1a2130;
+  --border: #262f42;
+  --text: #e8ecf4;
+  --muted: #8a93a8;
+  --accent: #6ee7ff;
+  --good: #4ade80;
+  --bad: #f87171;
+
+  --c1: #ef4444; /* red */
+  --c2: #22c55e; /* green */
+  --c3: #3b82f6; /* blue */
+  --c4: #eab308; /* yellow */
+  --c5: #f97316; /* orange */
+  --c6: #a855f7; /* purple */
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(1200px 600px at 50% -10%, #1c2436 0%, transparent 60%),
+    var(--bg);
+  color: var(--text);
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 4rem;
+}
+
+main {
+  width: 100%;
+  max-width: 640px;
+}
+
+header h1 {
+  font-size: 1.8rem;
+  letter-spacing: 0.15em;
+  margin: 0 0 0.4rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.wasm-badge {
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  background: linear-gradient(135deg, #654ff0, #6ee7ff);
+  color: #08111f;
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  font-weight: 700;
+  vertical-align: middle;
+}
+
+.tagline {
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  margin: 0 0 1.5rem;
+}
+.tagline code { color: var(--accent); }
+.tagline a { color: var(--accent); }
+
+#status-bar {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  margin-bottom: 1.2rem;
+  font-size: 0.85rem;
+}
+
+.stat { display: flex; align-items: baseline; gap: 0.35rem; }
+.stat .label { color: var(--muted); font-size: 0.7rem; }
+#engine-status.loading { color: var(--muted); }
+#engine-status.ready { color: var(--good); }
+#engine-status.ready::before { content: "● "; }
+#engine-status.loading::before { content: "○ "; }
+
+#status-bar button, #picker-actions button, #overlay-btn {
+  margin-left: auto;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.45rem 0.9rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.08s ease, border-color 0.15s ease;
+}
+#status-bar button:hover, #picker-actions button:hover:not(:disabled), #overlay-btn:hover {
+  border-color: var(--accent);
+}
+#status-bar button:active, #picker-actions button:active:not(:disabled) {
+  transform: scale(0.96);
+}
+#picker-actions button:disabled { opacity: 0.35; cursor: not-allowed; }
+
+#submit-btn:not(:disabled) {
+  background: linear-gradient(135deg, #2d6a4f, #40916c);
+  border-color: #52b788;
+}
+
+#board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.5rem 0.8rem;
+  animation: rowIn 0.3s ease;
+}
+
+@keyframes rowIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.row .row-index { color: var(--muted); font-size: 0.75rem; width: 1.2rem; }
+.row .pegs { display: flex; gap: 0.4rem; }
+.row .feedback { display: grid; grid-template-columns: repeat(2, 8px); gap: 3px; margin-left: auto; }
+
+.peg {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.15);
+  box-shadow: inset 0 -4px 8px rgba(0,0,0,0.35), 0 0 10px 0 var(--glow, transparent);
+}
+
+.peg.empty { background: #1c2333; border-style: dashed; border-color: #333d54; }
+.peg.c1 { background: radial-gradient(circle at 32% 28%, #ffb4b4, var(--c1)); --glow: color-mix(in srgb, var(--c1) 55%, transparent); }
+.peg.c2 { background: radial-gradient(circle at 32% 28%, #b8f5c9, var(--c2)); --glow: color-mix(in srgb, var(--c2) 55%, transparent); }
+.peg.c3 { background: radial-gradient(circle at 32% 28%, #b7d3ff, var(--c3)); --glow: color-mix(in srgb, var(--c3) 55%, transparent); }
+.peg.c4 { background: radial-gradient(circle at 32% 28%, #fef3ad, var(--c4)); --glow: color-mix(in srgb, var(--c4) 55%, transparent); }
+.peg.c5 { background: radial-gradient(circle at 32% 28%, #ffd2ad, var(--c5)); --glow: color-mix(in srgb, var(--c5) 55%, transparent); }
+.peg.c6 { background: radial-gradient(circle at 32% 28%, #e6c7fb, var(--c6)); --glow: color-mix(in srgb, var(--c6) 55%, transparent); }
+
+.dot { width: 8px; height: 8px; border-radius: 50%; }
+.dot.black { background: #0a0a0a; border: 1px solid #444; }
+.dot.white { background: #f5f5f5; border: 1px solid #999; }
+.dot.none { background: transparent; }
+
+#picker {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+#current-guess {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+  min-height: 44px;
+}
+
+#current-guess .peg { width: 40px; height: 40px; cursor: pointer; }
+#current-guess .peg:hover { filter: brightness(1.15); }
+
+#palette {
+  display: flex;
+  gap: 0.7rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+#palette button {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.15);
+  cursor: pointer;
+  box-shadow: inset 0 -4px 8px rgba(0,0,0,0.35);
+  transition: transform 0.1s ease;
+}
+#palette button:hover { transform: scale(1.1); }
+#palette button:active { transform: scale(0.95); }
+#palette button.c1 { background: radial-gradient(circle at 32% 28%, #ffb4b4, var(--c1)); }
+#palette button.c2 { background: radial-gradient(circle at 32% 28%, #b8f5c9, var(--c2)); }
+#palette button.c3 { background: radial-gradient(circle at 32% 28%, #b7d3ff, var(--c3)); }
+#palette button.c4 { background: radial-gradient(circle at 32% 28%, #fef3ad, var(--c4)); }
+#palette button.c5 { background: radial-gradient(circle at 32% 28%, #ffd2ad, var(--c5)); }
+#palette button.c6 { background: radial-gradient(circle at 32% 28%, #e6c7fb, var(--c6)); }
+
+#picker-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+#overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(4,6,12,0.75);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.25s ease;
+}
+#overlay.hidden { display: none; }
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+#overlay-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 2rem 2.4rem;
+  text-align: center;
+  max-width: 380px;
+  animation: cardIn 0.3s cubic-bezier(.2,1.4,.4,1);
+}
+@keyframes cardIn { from { transform: scale(0.85); opacity: 0; } to { transform: scale(1); opacity: 1; } }
+
+#overlay-title { margin: 0 0 0.5rem; font-size: 1.4rem; }
+#overlay-title.win { color: var(--good); }
+#overlay-title.lose { color: var(--bad); }
+#overlay-body { color: var(--muted); font-size: 0.85rem; line-height: 1.5; }


### PR DESCRIPTION
## Summary

- Real, deterministic pure scoring function running in-browser, called directly from a click UI — zero server round-trips after page load. Vendors `mvl-lang/mvl/examples/mastermind/code.mvl` (the pure half; `main.mvl` needs stdin, which `--backend=wasm` doesn't support — see experiment 011).
- Reverse-engineering `score_guess`'s struct-return ABI is what led to finding and fixing 3 real memory bugs in experiment 008's runtime (PRs #37, #38) — one of which turned out to be the actual root cause of a crash previously misfiled as a compiler bug (mvl-lang/mvl#2083, now corrected and closed).
- Found and worked around a 4th backend gap (dead-code elimination dropping string data for `pub` functions unreached from `main()`) rather than filing it — flagged for a filing decision, not filed unilaterally.

## Changes

### Added
- `vendor/code.mvl` — the pure Mastermind logic, `render_feedback` removed (fails to assemble under `--backend=wasm`, separate bug).
- `scripts/patch-data-segments.mjs` — works around the DCE bug, re-deriving the correct `(data ...)` segments from `color_name`'s own compiled body.
- `web/` — TypeScript UI: dark theme, glowing pegs, animated rows, win/loss overlay rendering the secret via a real WASM `color_name` call.
- `build.sh` / `serve.py` — build and static-serve, following the exp004 static-delivery pattern.

## Testing

- [x] Real headless Chromium (Playwright) end-to-end: engine load, guess submit + correct feedback pegs, attempt counting, win/loss overlay, New Game reset — zero console errors
- [x] Clean-room rebuild from nothing (`rm -rf web/dist web/node_modules web/code.wasm vendor/code.wat vendor/code.wasm && ./build.sh`) before this commit
- [x] Top-level README table updated (row 010 added, row 008's description corrected to reflect the #2083 correction)

No CI configured in this repo, merging directly once reviewed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>