### PR TITLE
feat: experiment 011 — Mastermind CLI, real WASI stdin, wasm32-wasip1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Reference: [AWS's Stealth Container Killer](https://aws.plainenglish.io/awss-ste
 | [008](experiments/008_mvl_example_wasm_harness/) | mvl_example_wasm_harness | done | Standalone (non-browser) host for `mvl build --backend=wasm` output — found and fixed 3 real memory/tag bugs in the ported runtime, one of which was mislabeled as a compiler bug (mvl-lang/mvl#2083, corrected and closed) |
 | [009](experiments/009_rust_native_host/) | rust_native_host | done | Native Rust host embedding `wasmtime` directly, no HTTP — checks a Medium article's "200µs" claim against true cold start and against its own methodology |
 | [010](experiments/010_mastermind_web/) | mastermind_web | done | Mastermind scored entirely by a compiled `.wasm` module, click-driven UI — reverse-engineered the struct-return ABI, worked around a dead-code-elimination bug dropping string data for unreached `pub` functions |
+| [011](experiments/011_mastermind_cli_wasi/) | mastermind_cli_wasi | done | Same game, pure Rust, `wasm32-wasip1`, real WASI `fd_read` stdin — proves genuine interactive I/O works under WASM/WASI, isolating that MVL's `--backend=wasm` gap is backend-specific, not a WASM/WASI limitation |
 
 ## Structure
 

--- a/experiments/011_mastermind_cli_wasi/.gitignore
+++ b/experiments/011_mastermind_cli_wasi/.gitignore
@@ -1,0 +1,2 @@
+# guest/target/, host/target/, Cargo.lock already covered by the
+# repo-root .gitignore.

--- a/experiments/011_mastermind_cli_wasi/README.md
+++ b/experiments/011_mastermind_cli_wasi/README.md
@@ -1,0 +1,130 @@
+# Experiment 011 — Mastermind CLI, real WASI stdin, `wasm32-wasip1`
+
+Direct answer to a specific question raised while building experiment 010: MVL's
+own `mvl build --backend=wasm` can't run `mvl-lang/mvl/examples/mastermind`'s
+interactive CLI (`main.mvl`) because its `runtime` import namespace has no stdin at
+all — `stdin`/`read_line` are undefined under that backend, confirmed directly (see
+experiment 010's README). That's a gap in *MVL's specific WASM backend design*, not
+a fundamental limitation of WASM or WASI. This experiment proves it: the same game,
+reimplemented in pure Rust, compiled to `wasm32-wasip1`, run under **real** WASI
+with **real** interactive stdin — no custom import namespace, no shim, standard
+WASI `fd_read` doing exactly what it's designed to do.
+
+## What's here
+
+- **`guest/`** — the Mastermind CLI itself, compiled to `wasm32-wasip1`. Not a fresh
+  design: `score_guess`/`count_blacks`/`count_color_at_mismatch` are line-for-line
+  ports of `mvl-lang/mvl/examples/mastermind/code.mvl`'s algorithms (same
+  mismatch-position restriction on both sides of the white-peg tally, same `min()`
+  to avoid double-counting), and the game loop/prompts mirror `main.mvl`'s
+  `read_guess`/`main` shape. Uses plain `std::io::stdin()` — under `wasm32-wasip1`
+  this compiles straight through to real WASI `fd_read` calls, no special handling
+  needed on the guest side at all.
+- **`host/`** — an embedded Rust host (same `wasmtime` crate pattern as experiment
+  009) that runs the guest with **explicit** WASI stdio wiring, so the actual wiring
+  code is visible and small:
+
+  ```rust
+  let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+  preview1::add_to_linker_sync(&mut linker, |ctx| ctx)?;   // registers fd_read, fd_write, etc.
+
+  let wasi = WasiCtxBuilder::new()
+      .inherit_stdin()   // guest's fd 0 -> this process's real stdin
+      .inherit_stdout()
+      .inherit_stderr()
+      .inherit_args()
+      .build_p1();
+  ```
+
+  This — a WASI context with stdio inherited, registered into a `Linker` before
+  instantiation — is the entire piece missing from MVL's WASM backend. Nothing
+  exotic; a few lines against a stable, standard API (`wasmtime-wasi` 27,
+  `preview1::add_to_linker_sync` — the flat-ABI preview1 entry point, not the
+  newer component-model preview2 API, since `wasm32-wasip1` is the older core-module
+  ABI).
+
+Both `wasmtime run guest/....wasm` directly and the embedded host produce identical
+behavior — the host exists to make the wiring explicit and inspectable, not because
+`wasmtime run` needs help; it already wires preview1 stdio by default.
+
+## Proof: genuinely interactive, not just a piped file
+
+A whole canned input file piped into `wasmtime run` would prove the mechanics work,
+but not that the process is actually *blocking on real reads* rather than the input
+having been available all along. Verified with a real pty (`pty.openpty()` +
+`select()` with a timeout), sending one line at a time and confirming no output
+arrives between prompts until a line is actually sent — a genuine send/receive
+round-trip, not a batch:
+
+```
+=== output before any input ===
+...
+Attempt 1 of 10 -- your guess:
+                                    <- process blocks here, confirmed via select() timeout
+=== sending '1 2 3 4' ===
+1 2 3 4
+  -> blacks: 1  whites: 1
+Attempt 2 of 10 -- your guess:
+                                    <- blocks again
+=== sending '6 5 4 3' ===
+6 5 4 3
+  -> blacks: 0  whites: 3
+...
+```
+
+Confirmed for both the `wasmtime run` path and the embedded host. Feedback values
+hand-verified against the actual generated secret in both runs.
+
+## A real gotcha: stdout buffering under WASI
+
+Rust's `stdout()` is block-buffered by default when not attached to a TTY — which a
+WASI-hosted process, from the guest's point of view, never is. Without an explicit
+`.flush()` after every prompt, a prompt can sit in the buffer while the process
+blocks on `read_line`, making a genuinely-working interactive session *look* hung
+(output arrives all at once, batched, whenever the buffer happens to fill or the
+process exits). Every `say!` in `guest/src/main.rs` flushes explicitly — worth
+calling out since it's an easy way to build something that "works" under a piped
+test but appears broken interactively.
+
+## Usage
+
+```bash
+./build.sh
+
+# Either run path — pick one:
+wasmtime run guest/target/wasm32-wasip1/release/mastermind-guest.wasm
+./host/target/release/mastermind-host
+```
+
+Both read real stdin interactively. Non-interactive verification:
+
+```bash
+printf "1 2 3 4\n2 3 4 5\n" | wasmtime run guest/target/wasm32-wasip1/release/mastermind-guest.wasm
+```
+
+## What this means for MVL
+
+Making `mvl-lang/mvl/examples/mastermind` (or any MVL program using `std.io.stdin`)
+actually run under `--backend=wasm` would need: (1) wiring `fd_read` (and friends)
+into whatever host runs the compiled module — `mvl-playground`'s browser Worker
+currently has no stdin source to wire it to anyway, so this would need a different
+host, not just a runtime patch — and (2) `code.mvl`'s own `parse_guess` fixed, since
+it currently traps on call regardless of where its input comes from (see experiment
+010's README — "contained unsupported constructs"). Neither is a WASM/WASI
+limitation; both are specific, addressable gaps in MVL's current WASM backend and
+runtime, demonstrated concretely here rather than asserted.
+
+## Structure
+
+```
+011_mastermind_cli_wasi/
+├── README.md
+├── build.sh
+├── guest/
+│   ├── Cargo.toml
+│   └── src/main.rs        # the game — real stdin, compiled to wasm32-wasip1
+└── host/
+    ├── Cargo.toml
+    └── src/main.rs        # embedded wasmtime host, explicit WASI stdio wiring
+    # */target/, Cargo.lock are build.sh output, gitignored
+```

--- a/experiments/011_mastermind_cli_wasi/build.sh
+++ b/experiments/011_mastermind_cli_wasi/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# build.sh — compile the mastermind CLI guest to wasm32-wasip1 and the
+# embedded host that runs it with explicit WASI stdio wiring.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "→ guest: cargo build --release --target wasm32-wasip1"
+(cd guest && cargo build --release --target wasm32-wasip1)
+
+echo "→ host: cargo build --release"
+(cd host && cargo build --release)
+
+echo
+echo "done. Run with either:"
+echo "  wasmtime run guest/target/wasm32-wasip1/release/mastermind-guest.wasm"
+echo "  ./host/target/release/mastermind-host"

--- a/experiments/011_mastermind_cli_wasi/guest/Cargo.toml
+++ b/experiments/011_mastermind_cli_wasi/guest/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mastermind-guest"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "mastermind-guest"
+path = "src/main.rs"
+
+[profile.release]
+opt-level = "s"
+panic = "abort"

--- a/experiments/011_mastermind_cli_wasi/guest/src/main.rs
+++ b/experiments/011_mastermind_cli_wasi/guest/src/main.rs
@@ -1,0 +1,198 @@
+// mastermind-guest — the same Mastermind game as mvl-lang/mvl/examples/mastermind
+// (main.mvl + code.mvl), reimplemented in pure Rust and compiled to
+// wasm32-wasip1, to prove real interactive stdin works under WASM/WASI when a
+// host actually wires fd_read — which is exactly the piece MVL's own
+// `--backend=wasm` doesn't have (its `runtime` import namespace has no stdin
+// at all; `stdin`/`read_line` are undefined under that backend, and code.mvl's
+// own parse_guess traps on call anyway — see experiment 010's README).
+//
+// Scoring logic (`score_guess`) is a deliberate line-for-line port of
+// code.mvl's count_blacks/count_color_at_mismatch/score_guess, not a
+// reimplementation from the rules description — same restriction to
+// mismatched positions on both sides, same min() to avoid double-counting.
+//
+// stdout is flushed after every write. Under WASI (not a TTY), Rust's stdout
+// is block-buffered by default — a prompt printed without a flush can sit in
+// the buffer while the process blocks on read_line, making an interactive
+// session look hung. Verified this matters (see README's "flush" note).
+use std::io::{self, BufRead, Write};
+
+const CODE_LEN: usize = 4;
+const NUM_COLORS: u8 = 6;
+const MAX_ATTEMPTS: u32 = 10;
+
+#[derive(Clone, Copy)]
+struct Feedback {
+    blacks: u8,
+    whites: u8,
+}
+
+fn color_name(n: u8) -> &'static str {
+    match n {
+        1 => "red",
+        2 => "green",
+        3 => "blue",
+        4 => "yellow",
+        5 => "orange",
+        6 => "purple",
+        _ => "?",
+    }
+}
+
+fn render_code(code: &[u8; CODE_LEN]) -> String {
+    code.iter().map(|&n| color_name(n)).collect::<Vec<_>>().join(" ")
+}
+
+fn render_feedback(fb: Feedback) -> String {
+    format!("blacks: {}  whites: {}", fb.blacks, fb.whites)
+}
+
+// Direct port of code.mvl's count_blacks: positions where guess matches
+// secret exactly.
+fn count_blacks(secret: &[u8; CODE_LEN], guess: &[u8; CODE_LEN]) -> u32 {
+    secret.iter().zip(guess.iter()).filter(|(s, g)| s == g).count() as u32
+}
+
+// Direct port of code.mvl's count_color_at_mismatch: occurrences of `color`
+// in `xs`, restricted to positions where `xs` and `other` differ — applied
+// to both sides in score_guess so black-peg positions are never counted
+// twice for whites.
+fn count_color_at_mismatch(xs: &[u8; CODE_LEN], other: &[u8; CODE_LEN], color: u8) -> u32 {
+    xs.iter()
+        .zip(other.iter())
+        .filter(|(&x, &o)| x == color && x != o)
+        .count() as u32
+}
+
+// Direct port of code.mvl's score_guess.
+fn score_guess(secret: &[u8; CODE_LEN], guess: &[u8; CODE_LEN]) -> Feedback {
+    let blacks = count_blacks(secret, guess);
+    let mut whites = 0u32;
+    for color in 1..=NUM_COLORS {
+        let in_secret = count_color_at_mismatch(secret, guess, color);
+        let in_guess = count_color_at_mismatch(guess, secret, color);
+        whites += in_secret.min(in_guess);
+    }
+    Feedback { blacks: blacks as u8, whites: whites as u8 }
+}
+
+// Direct port of code.mvl's parse_guess: exactly four numbers in 1..=6,
+// whitespace-separated. Anything else -> None (Invalid, does not consume
+// an attempt) — matches main.mvl's read_guess semantics.
+fn parse_guess(input: &str) -> Option<[u8; CODE_LEN]> {
+    let parts: Vec<&str> = input.trim().split_whitespace().collect();
+    if parts.len() != CODE_LEN {
+        return None;
+    }
+    let mut code = [0u8; CODE_LEN];
+    for (i, part) in parts.iter().enumerate() {
+        let n: i32 = part.parse().ok()?;
+        if !(1..=NUM_COLORS as i32).contains(&n) {
+            return None;
+        }
+        code[i] = n as u8;
+    }
+    Some(code)
+}
+
+// No RNG crate — this is a spike, not a security-sensitive shuffle. Seeded
+// from WASI's clock_time_get (via SystemTime, which wasmtime's default WASI
+// implementation backs for real), not "random" in a cryptographic sense, but
+// varies run to run same as code.mvl's std.random.int would.
+struct Xorshift64(u64);
+impl Xorshift64 {
+    fn new(seed: u64) -> Self {
+        Xorshift64(seed | 1)
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn range_1_to_6(&mut self) -> u8 {
+        1 + (self.next_u64() % NUM_COLORS as u64) as u8
+    }
+}
+
+fn seed_from_clock() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9E3779B97F4A7C15)
+}
+
+fn main() {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+
+    macro_rules! say {
+        ($($arg:tt)*) => {{
+            writeln!(out, $($arg)*).ok();
+            out.flush().ok(); // see top-of-file comment on WASI stdout buffering
+        }};
+    }
+
+    say!("Mastermind (Rust, wasm32-wasip1, real WASI stdin)");
+    say!("I picked a secret code of 4 colors (repeats allowed):");
+    say!("  1 = red    2 = green  3 = blue");
+    say!("  4 = yellow 5 = orange 6 = purple");
+    say!("Guess with four numbers separated by spaces, e.g. `1 2 3 4`.");
+    say!("Feedback: black = right color + position, white = right color only.");
+
+    let mut rng = Xorshift64::new(seed_from_clock());
+    let secret: [u8; CODE_LEN] = [
+        rng.range_1_to_6(),
+        rng.range_1_to_6(),
+        rng.range_1_to_6(),
+        rng.range_1_to_6(),
+    ];
+
+    let mut attempt: u32 = 1;
+    loop {
+        if attempt > MAX_ATTEMPTS {
+            say!("Out of attempts -- the code was: {}", render_code(&secret));
+            break;
+        }
+
+        say!("Attempt {} of {} -- your guess:", attempt, MAX_ATTEMPTS);
+        out.flush().ok();
+
+        let line = match lines.next() {
+            None => {
+                say!("Goodbye! The code was: {}", render_code(&secret));
+                break;
+            }
+            Some(Err(_)) => {
+                say!("Goodbye! The code was: {}", render_code(&secret));
+                break;
+            }
+            Some(Ok(line)) => line,
+        };
+
+        if line.trim().is_empty() {
+            say!("Goodbye! The code was: {}", render_code(&secret));
+            break;
+        }
+
+        match parse_guess(&line) {
+            None => {
+                say!("Invalid guess -- enter four numbers 1-6, e.g. `1 2 3 4`.");
+            }
+            Some(guess) => {
+                let fb = score_guess(&secret, &guess);
+                say!("  -> {}", render_feedback(fb));
+                if fb.blacks as usize == CODE_LEN {
+                    say!("Cracked it in {} attempt(s)!", attempt);
+                    break;
+                }
+                attempt += 1;
+            }
+        }
+    }
+}

--- a/experiments/011_mastermind_cli_wasi/host/Cargo.toml
+++ b/experiments/011_mastermind_cli_wasi/host/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mastermind-host"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "mastermind-host"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.104"
+wasmtime = "27"
+wasmtime-wasi = "27"

--- a/experiments/011_mastermind_cli_wasi/host/src/main.rs
+++ b/experiments/011_mastermind_cli_wasi/host/src/main.rs
@@ -1,0 +1,65 @@
+// mastermind-host — an embedded Rust host running the mastermind-guest
+// wasm32-wasip1 binary, with EXPLICIT WASI stdio wiring.
+//
+// This is the piece MVL's own `mvl build --backend=wasm` doesn't have: its
+// `runtime` import namespace (~60 hand-written string/array/option/result/
+// map functions, see experiment 008) has no stdin at all, so `stdin`/
+// `read_line` are undefined under that backend. Real interactive I/O under
+// WASM isn't impossible — WASI already solves it, and it's exactly these
+// few lines: a WasiCtx with stdio inherited, wired into a Linker before
+// instantiation.
+use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime_wasi::preview1::{self, WasiP1Ctx};
+use wasmtime_wasi::WasiCtxBuilder;
+
+const WASM_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../guest/target/wasm32-wasip1/release/mastermind-guest.wasm"
+);
+
+fn main() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
+    let engine = Engine::new(&config)?;
+
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    // THE wiring: preview1 WASI syscalls (fd_read, fd_write, clock_time_get,
+    // etc.) registered into the linker so the guest's `call $fd_read` (and
+    // everything Rust's std::io::stdin() compiles down to) resolves to a
+    // real implementation instead of an unsatisfied import. wasm32-wasip1
+    // (this guest's target) uses the "preview1" flat-ABI WASI, not the
+    // component-model preview2 — hence `preview1::add_to_linker_sync`, not
+    // the crate-root `add_to_linker_sync` (which is preview2/component-only).
+    preview1::add_to_linker_sync(&mut linker, |ctx| ctx)?;
+
+    // inherit_stdin()/inherit_stdout()/inherit_stderr(): the guest's fd 0/1/2
+    // are wired directly to THIS process's real stdio — genuine fd_read
+    // against the terminal (or whatever's piped into this process), not a
+    // simulated/buffered fake.
+    let wasi = WasiCtxBuilder::new()
+        .inherit_stdin()
+        .inherit_stdout()
+        .inherit_stderr()
+        .inherit_args()
+        .build_p1();
+
+    let mut store = Store::new(&engine, wasi);
+    let module = Module::from_file(&engine, WASM_PATH)?;
+    let instance = linker.instantiate(&mut store, &module)?;
+
+    // wasm32-wasip1 binaries expose their entry point as `_start`, the same
+    // convention `wasmtime run` itself uses under the hood.
+    let start = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
+    match start.call(&mut store, ()) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // A clean WASI exit (including a nonzero process::exit) surfaces
+            // as a trap carrying an I32Exit — not a real crash. Anything
+            // else is a genuine guest fault and should propagate.
+            if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
+                std::process::exit(exit.0);
+            }
+            Err(e)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Direct answer to a question raised while building experiment 010: MVL's `--backend=wasm` can't run mastermind's interactive CLI (no stdin in its `runtime` import namespace). Proves that's backend-specific, not a WASM/WASI limitation — same game, pure Rust, `wasm32-wasip1`, real WASI `fd_read` stdin.
- `guest/`: line-for-line port of `code.mvl`'s scoring algorithms, plain `std::io::stdin()`.
- `host/`: embedded `wasmtime` host (same pattern as experiment 009) with explicit WASI stdio wiring in ~10 lines — the actual piece missing from MVL's backend, made visible and inspectable.

## Testing

- [x] Piped stdin, both run paths (`wasmtime run` and embedded host), scoring hand-verified against generated secrets
- [x] Genuine interactivity proven via a real pty + `select()` with a timeout — process actually blocks between prompts, not a batch-piped file
- [x] Clean-room rebuild (`rm -rf */target *.lock`, rebuild via `build.sh`) before this commit
- [x] Top-level README table updated

No CI configured in this repo, merging directly once reviewed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>