### PR TITLE
chore: re-add dependabot npm coverage for js-spin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/experiments/003_wasm_compile/js-spin"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip"
     directory: "/experiments/003_wasm_compile"
     schedule:


### PR DESCRIPTION
## Summary

- PR #23 (esbuild 0.25.12 -> 0.28.1, two real security advisories) was orphaned: dependabot reported its originating `dependabot.yml` entry for `/experiments/003_wasm_compile/js-spin` no longer exists, so it couldn't be rebased.
- Closed #23 per dependabot's own instruction; this restores the config entry so it opens a fresh, correctly-scoped replacement PR.

## Not addressed here (flagged separately)

Most npm/Cargo manifests added since `dependabot.yml` was last touched have zero coverage — experiments 004-011's `web/`/`rust/`/`guest/`/`host/` subdirs, `as-hello`, 006's two manifests. Out of scope for this PR (which is specifically the #23 fix); happy to do a follow-up sweep if wanted.

No CI configured in this repo, merging directly once reviewed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>