### PR TITLE
docs: document five archetypal architectures across all 11 experiments

### DIFF
--- a/.openspec/adr/0002-archetype-browser-worker-wasi-shim.md
+++ b/.openspec/adr/0002-archetype-browser-worker-wasi-shim.md
@@ -1,0 +1,98 @@
+# Archetype: Browser Worker + Vendored WASI Shim
+
+> Exemplified by: [experiment 004](../../experiments/004_static_wasi_hello/),
+> [005](../../experiments/005_stdout_capture_load/),
+> [006](../../experiments/006_worker_kill_switch/).
+> This is `mvl-lang/mvl-playground`'s actual production architecture — 004 was
+> built specifically to replicate it and measure it in isolation.
+
+## System Context
+
+A visitor loads a **static** web page — no backend process exists at request time,
+no server-side compute of any kind. The page's own JavaScript spawns a Web Worker,
+which loads a compiled `.wasm` module and runs it against a **JavaScript
+emulation** of WASI, entirely inside the browser's own sandbox.
+
+```mermaid
+flowchart TB
+    person(["Visitor's browser tab"])
+
+    subgraph sys["System: static-hosted WASM demo"]
+        direction TB
+        page["Main-thread page<br/>(index.html + tiny bootstrap JS)"]
+        worker["Web Worker<br/>(worker.js)"]
+        shim["Vendored WASI shim<br/>(@bjorn3/browser_wasi_shim)"]
+        wasm["Compiled guest<br/>(wasm32-wasip1 core module)"]
+    end
+
+    host["Static file host<br/>(any CDN / python3 -m http.server)"]
+
+    person -->|"GET /"| host
+    host -->|"html + js + wasm bytes, once"| page
+    page -->|"new Worker(...)"| worker
+    worker -->|"WebAssembly.instantiate against wasiImport"| shim
+    shim <-->|"fd_write / fd_read / clock_time_get, emulated"| wasm
+    worker -->|"postMessage: stdout, exit code"| page
+```
+
+## Containers
+
+| Container | Path | Role |
+|-----------|------|------|
+| Static host | any CDN, or `python3 -m http.server` in dev | Serves bytes once; does zero compute for the request lifecycle. Not "serverless" in the FaaS sense — genuinely *no server* after the initial GET. |
+| Main-thread page | `web/index.html` | Bootstraps the Worker, receives results via `postMessage` |
+| Web Worker | `web/worker.js` | Owns the `WebAssembly.instantiate` call and the WASI import object; runs on its own thread so it can be `.terminate()`d without freezing the tab |
+| Vendored WASI shim | `@bjorn3/browser_wasi_shim`, vendored at build time (no CDN, no bundler) | A JS-side emulation of `wasi_snapshot_preview1` — `fd_write`/`fd_read`/`clock_time_get`/etc. implemented over JS objects, not real OS syscalls |
+| Guest module | Rust compiled to **`wasm32-wasip1`** | Confirmed the *only* viable target: `wasm32-wasip2` output fails at `WebAssembly.compile()` itself (`expected version 01 00 00 00, found 0d 00 01 00`) — a parse-level rejection, one layer below the WASI-import question, because wasip2 emits the component-model binary format and a plain `WebAssembly.compile()` only accepts core modules |
+
+## Verified facts, not assumptions
+
+- **Entry point convention**: `worker.js` calls `wasi.start(instance)`, which wraps
+  `_start`. This particular shim version **catches its own internal
+  `WASIProcExit`** and returns the exit code rather than throwing it — confirmed by
+  reading `dist/wasi.js` directly, not inferred from a stack trace (exp 004).
+- **`file://` does not work.** Constructing a module Worker from a `file://` page
+  fails with `origin 'null'` — a real static server (even a one-line dev one) is
+  required for every experiment in this archetype (exp 004).
+- **`SharedArrayBuffer` needs COOP/COEP headers**, which a plain
+  `python3 -m http.server` does not send. Verified directly: `typeof
+  SharedArrayBuffer` is `"undefined"` without them, becomes available once a
+  custom `coi_server.py` adds `Cross-Origin-Opener-Policy: same-origin` /
+  `Cross-Origin-Embedder-Policy: require-corp` (exp 006 — needed there for a
+  cross-thread heartbeat via `Atomics`; **not** needed by 004/005, which don't use
+  `SharedArrayBuffer` at all).
+
+## Measured, not projected
+
+| Metric | Value | Source |
+|---|---|---|
+| Cold start (10 runs, min / median / max) | 22.2 / 22.7 / 100.6 ms | exp 004. Run 1's 100.6ms outlier attributed to first-navigation JIT warmup, reported rather than dropped. |
+| Artifact size | 39.4KB (`.wasm` alone), 85.6KB (full page, no bundler) | exp 004 |
+| stdout/stderr capture, per-line cost at scale | 0.0425ms/line at N=10 → 0.0016ms/line at N=100,000 (**~26x decrease**, not constant as naively assumed) | exp 005 |
+| DOM-append overhead at N=100,000 lines | ~780ms extra (**>3x**) vs. capturing without touching the DOM | exp 005 — worker-side WASM execution itself barely moves (315.9ms → 337.6ms); the cost is in `appendChild`, not the WASM |
+| `Worker.terminate()` against a genuine infinite loop | **~2.137 seconds** to actually die (8 measurements, 2,134–2,138ms, ≤4ms spread), regardless of whether the loop allocates memory | exp 006 — refutes "close to instant"; the call itself returns in under a millisecond, but *execution continues* for ~2.1s after that |
+
+## Constraints this archetype imposes
+
+- Guest **must** target `wasm32-wasip1`. Not a preference — `wasm32-wasip2` is
+  structurally incompatible with a plain `WebAssembly.compile()` call.
+- No real stdin. A shim emulates WASI *syscalls*, not a terminal — console-driven,
+  interactive programs (`read_line`-style loops) have nothing real to read from.
+  See [ADR-0005](0005-archetype-embedded-runtime-library.md) for the archetype
+  that actually solves this.
+- `Worker.terminate()` is a real kill switch but not an instant one — a caller
+  relying on it as a timeout mechanism needs a budget measured in seconds, not
+  milliseconds, for CPU-bound guests.
+- Shim correctness is now part of the trust boundary: WASI here is *emulated in
+  JavaScript*, not backed by the OS. A shim bug is indistinguishable from a guest
+  bug until proven otherwise.
+
+## When this is the right shape
+
+Zero-marginal-cost hosting (static files, no backend to run or pay for), and the
+workload is either non-interactive (batch compute, one-shot transforms) or drives
+its own UI directly rather than reading a console. This is exactly
+`mvl-lang/mvl-playground`'s bet: ship the compiler's `--backend=wasm` output as a
+static artifact, run it in a Worker, show the captured output. It stops being the
+right shape the moment the guest needs `stdin` for real, or needs to run longer
+than a few seconds under a caller that must be able to cancel it promptly.

--- a/.openspec/adr/0003-archetype-custom-hand-rolled-abi.md
+++ b/.openspec/adr/0003-archetype-custom-hand-rolled-abi.md
@@ -1,0 +1,100 @@
+# Archetype: Custom Hand-Rolled Import Namespace (Non-WASI ABI)
+
+> Exemplified by: [experiment 007](../../experiments/007_custom_runtime_vs_interpreter/)'s
+> `custom_runtime` leg (minimal, 3-function version),
+> [008](../../experiments/008_mvl_example_wasm_harness/) and
+> [010](../../experiments/010_mastermind_web/) (MVL's real ~60-function version).
+
+## System Context
+
+Instead of targeting WASI at all, the compiler emits a **bespoke import
+namespace** — a `WebAssembly.instantiate(bytes, { runtime: {...} })` call where
+`runtime` is not a standard world, just whatever functions a hand-written JS
+module chooses to implement. Portable to *any* JS host — this is the one
+archetype in the repo proven to work identically in a browser (010) and in a bare
+Node.js process (007, 008), because there's no WASI-shaped assumption (no Worker
+requirement, no `file://` restriction) baked into it at all.
+
+```mermaid
+flowchart TB
+    caller(["Caller<br/>(UI click handler, or a top-level driver script)"])
+
+    subgraph sys["System: custom-ABI WASM host (browser OR plain Node — same shape)"]
+        direction TB
+        host_js["Hand-written JS runtime<br/>(runtime.js — the ENTIRE ABI contract)"]
+        wasm["Compiled guest<br/>(no WASI imports at all)"]
+    end
+
+    caller -->|"call an exported pub fn directly<br/>(e.g. score_guess(secret, guess))"| wasm
+    wasm <-->|"~3 to ~60 bespoke functions:<br/>string/array/option/result/struct ops"| host_js
+    wasm -->|"return value<br/>(scalar, multi-value, or a raw memory pointer)"| caller
+```
+
+## Containers
+
+| Container | Path | Role |
+|-----------|------|------|
+| Guest module | 007: Rust → `wasm32-unknown-unknown`. 008/010: MVL source → `mvl build --backend=wasm` | Zero WASI imports. All non-trivial operations (even string concatenation) are calls into the custom namespace. |
+| Hand-written runtime | 007: 37 lines of JS. 008/010: `mvl-runtime.js`, a byte-faithful port of `mvl-lang/mvl-playground`'s own `web/src/runtime/mvl-runtime.ts` | This file **is** the ABI. There is no spec, no validator, no third party implementing this namespace anywhere else — it is exactly as correct as whoever wrote it made it. |
+| Caller | 007: a Node script calling one exported function. 010: a UI click handler calling `score_guess()`/`color_name()` on demand, with no single "run" entry point at all | Decides when and how the guest's exports get invoked — this archetype has no equivalent of `_start`; a "library" module (010) may never run anything end-to-end, only answer individual function calls. |
+
+## Two real shapes inside this one archetype
+
+- **Command-style, hybrid** (008): the compiled module still has a `_start` and
+  still needs *real* WASI for stdio (`wasi_snapshot_preview1.fd_write`) — the
+  custom namespace only replaces data-structure operations, not I/O. Two import
+  namespaces satisfied at once.
+- **Pure library-style** (010): no `_start`, no I/O of any kind, no WASI import at
+  all. The module is a portable, sandboxed collection of pure functions the host
+  calls whenever it wants. Simplest and most decoupled of anything in this repo.
+
+## The scale range is real, not incidental
+
+| | Import surface | Artifact | Cold start | Hand-written host code |
+|---|---|---|---|---|
+| 007 (minimal) | 3 functions (`string_new`/`string_concat`/`string_write`) | **302 bytes** | **0.28ms** | 78 lines total (41 Rust + 37 JS) |
+| 008/010 (MVL's real convention) | ~60 functions (string/array/option/result/map/struct ops) | varies by program | not benchmarked | `mvl-runtime.js`, ~340 lines |
+
+007's minimal leg exists specifically to show the floor of this archetype: how
+small can a "compile a program to WASM and run it" story get if you refuse both
+WASI and an interpreter. 302 bytes and 0.28ms is the answer — compare against
+[ADR-0006](0006-archetype-interpreter-in-wasm.md)'s 11.9–17.6MB and hundreds of
+milliseconds for the same rough job done by shipping a language runtime instead.
+
+## The real, demonstrated cost of this archetype
+
+This is not a hypothetical trade-off — it happened, in this repo, this session.
+`_mvl_struct_alloc`, `_mvl_array_get`, and every string-creating function in
+`mvl-runtime.js` returned JS-side handle-table indices (small incrementing
+integers), but the *compiled module itself* does raw `i64.store`/`i64.load`/
+`i32.load` directly on those return values — confirmed by reading the actual WAT
+body of `score_guess` (a struct-returning function) and of a `for x in [array
+literal]` loop. A handle used as a raw memory address corrupts real module memory.
+
+**One instance of this bug had already been misfiled as a compiler bug**
+(`mvl-lang/mvl#2083`, "actor message routing crash") before being traced back to
+this exact ABI boundary and corrected. There is no framework here to catch this
+class of error — the entire memory-safety contract between guest and host is
+whatever the hand-written `runtime.js` happens to get right. See
+`experiments/008_mvl_example_wasm_harness/README.md` for the full writeup; this is
+the archetype's central trade-off, not a footnote.
+
+Also confirmed in exp010: **string-literal data can silently disappear.**
+`mvl build --backend=wasm`'s dead-code elimination drops `(data ...)` segments for
+string literals used only by `pub` functions never called from `main()` — the
+function still exports correctly, its `i32.const <ptr>` instructions still look
+right, they just point at nothing. Worked around with a small build-time patch
+script rather than blocked by it; the underlying gap is still open (flagged
+against `mvl-lang/mvl#2084`, not yet fixed upstream).
+
+## When this is the right shape
+
+The workload is small, self-contained, and doesn't need WASI's assumptions
+(filesystem, real stdio, clock) — or a language's compiler doesn't target WASI at
+all and inventing a minimal namespace is genuinely cheaper than adapting to one
+that does. Library-style modules (010) that expose a handful of pure functions to
+a UI are the strongest fit: no entry point ceremony, smallest possible surface.
+Reach for a standard ABI instead ([ADR-0004](0004-archetype-prebuilt-server-http-blackbox.md)
+or [ADR-0005](0005-archetype-embedded-runtime-library.md)) the moment correctness
+at the memory boundary matters more than footprint — this archetype offers no
+safety net for that boundary at all.

--- a/.openspec/adr/0004-archetype-prebuilt-server-http-blackbox.md
+++ b/.openspec/adr/0004-archetype-prebuilt-server-http-blackbox.md
@@ -1,0 +1,96 @@
+# Archetype: Pre-Built Server, Consumed as an HTTP Black Box
+
+> Exemplified by: [experiment 001](../../experiments/001_hello_world/)'s leg 3
+> (Rust, `wasmtime serve`), and [003](../../experiments/003_wasm_compile/)'s
+> js-spin / py-raw / py-spin / rust / as-hello legs (`spin up` /
+> `wasmtime serve`).
+
+## System Context
+
+An off-the-shelf CLI (`wasmtime serve`, `spin up`) **is** the entire host. There
+is no custom host code at all — the CLI loads a compiled component and routes
+HTTP requests to it directly. This is the most standardized shape in the repo:
+any language with WASI-HTTP component tooling can fill the same box.
+
+```mermaid
+flowchart TB
+    client(["HTTP client<br/>(curl, hey, ab)"])
+
+    subgraph sys["System: WASI-HTTP component, served by an off-the-shelf runtime"]
+        direction TB
+        cli["Runtime CLI<br/>(wasmtime serve / spin up)<br/>— zero custom host code"]
+        component["Compiled component<br/>(wasi:http/incoming-handler world)"]
+    end
+
+    client -->|"HTTP request"| cli
+    cli -->|"handle(IncomingRequest, ResponseOutparam)"| component
+    component -->|"response"| cli
+    cli -->|"HTTP response"| client
+```
+
+## Containers
+
+| Container | Path | Role |
+|-----------|------|------|
+| Runtime CLI | `wasmtime serve --addr ...` (exp 001 leg3, 003's rust leg) or `spin up` (003's js-spin/py-spin legs) | The entire host process. Not written by this repo — a general-purpose tool. |
+| Compiled component | one per language/toolchain (see below) | Implements `wasi:http/incoming-handler` — a real Component Model world, not preview1's flat ABI |
+
+## Proven interchangeable across source languages
+
+| Leg | Toolchain | Confirmed target |
+|---|---|---|
+| 001 leg3 / 003 rust | Rust | `wasm32-wasip2`, `wasi::http::proxy::export!(Component ...)` |
+| 003 js-spin | JavaScript | Spin's `http-js` template, esbuild-bundled then componentized via `jco` |
+| 003 py-raw | Python | `componentize-py` against a raw WIT world |
+| 003 py-spin | Python | Spin's `http-py` template |
+| 003 as-hello | AssemblyScript | `asc` + `wasm-tools` — present on disk, **not currently documented in 003's own README** (a real drift, flagged separately, not fixed as part of this ADR) |
+
+Four different source languages, same host shape, same world. That interchangeability
+is this archetype's whole reason to exist.
+
+## The real, demonstrated risk: component-model version skew
+
+Neither 001 nor 003 has measured numbers yet (both experiments are genuinely
+"results pending" — every results table is a blank placeholder, reported
+honestly rather than filled with guesses). But [experiment
+007](../../experiments/007_custom_runtime_vs_interpreter/) attempted to reuse this
+exact shape (its `componentize-py` leg, built in-place from 003's `python-raw/`)
+and hit a live failure, not a hypothetical one:
+
+```
+component imports instance wasi:cli/environment@0.2.4,
+but a matching implementation was not found in the linker
+```
+
+A genuine WASI-preview2 world-version mismatch between the installed `wasmtime`
+and `componentize-py`'s generated bindings — a toolchain/environment gap, not a
+defect in the component itself. A fallback attempt via `python-spin` hit a
+*second*, independent gap: that directory has no `wit/` tracked at all. Both are
+reported as-is in 007's README (including an explicit `N/A` in its results table
+for the measurement that couldn't be taken) rather than papered over.
+
+## Constraints this archetype imposes
+
+- Guest must target a real Component Model world (`wasi:http/incoming-handler`),
+  not preview1's flat ABI — a materially bigger lift than
+  [ADR-0002](0002-archetype-browser-worker-wasi-shim.md)'s plain core module.
+- The runtime CLI's own version and the guest toolchain's generated bindings must
+  agree on a WASI-preview2 world version. 007 shows this is a real, current
+  failure mode, not a solved problem.
+- Every request pays full HTTP framing plus whatever the component-model
+  canonical ABI costs to cross — there is no path to the microsecond-scale calls
+  [ADR-0005](0005-archetype-embedded-runtime-library.md) measures, because HTTP
+  and the CLI subprocess boundary are both mandatory parts of this shape.
+- "Cold start" here includes the CLI subprocess's own startup, not just the
+  guest's instantiation — a different, larger number than any Worker- or
+  library-embedded archetype in this repo.
+
+## When this is the right shape
+
+Multiple teams/languages need to ship interchangeable HTTP handlers behind one
+stable interface, and you want zero custom host code — any WASI-HTTP-compliant
+runtime (Wasmtime, Spin, in principle wasmCloud/WasmEdge) can serve the same
+artifact. It is the wrong shape for latency-sensitive in-process calls (see
+[ADR-0005](0005-archetype-embedded-runtime-library.md) instead) and for anything
+that must run with zero backend process at all (see
+[ADR-0002](0002-archetype-browser-worker-wasi-shim.md)).

--- a/.openspec/adr/0005-archetype-embedded-runtime-library.md
+++ b/.openspec/adr/0005-archetype-embedded-runtime-library.md
@@ -1,0 +1,101 @@
+# Archetype: Embedded Runtime as a Library (In-Process, Native Host)
+
+> Exemplified by: [experiment 009](../../experiments/009_rust_native_host/)
+> (zero-import pure-compute guest) and
+> [011](../../experiments/011_mastermind_cli_wasi/)'s `host/`
+> (full WASI command guest, real interactive stdin).
+
+## System Context
+
+The host is itself a compiled native binary that **links the WASM engine as a
+library** — no subprocess, no HTTP, no CLI boundary of any kind. The only
+overhead is whatever WASM's own linear-memory ABI requires. This is the tightest
+possible integration in the repo, and the only one where "real interactive stdin
+under WASM" was proven end-to-end (011).
+
+```mermaid
+flowchart TB
+    caller(["Native process's own control flow<br/>(e.g. an interactive terminal session)"])
+
+    subgraph sys["System: one native binary, wasmtime linked in"]
+        direction TB
+        embed["Embedding code<br/>(Engine / Linker / Store / Module / Instance)"]
+        wasi_wire["WasiCtx wiring<br/>(only when the guest needs WASI — see below)"]
+        wasm["Compiled guest<br/>(wasm32-unknown-unknown OR wasm32-wasip1)"]
+    end
+
+    caller -->|"typed function call, in-process"| embed
+    embed -->|"instantiate + call"| wasm
+    wasi_wire -.->|"fd_read/fd_write registered into the Linker<br/>BEFORE instantiation, only if guest is a WASI command"| wasm
+    wasm -->|"typed return value"| caller
+```
+
+## Containers
+
+| Container | Path | Role |
+|-----------|------|------|
+| Embedding host | 009: `host/src/main.rs`. 011: `host/src/main.rs` | A normal compiled Rust binary linking the `wasmtime` crate directly (`Engine`, `Module`, `Store`, `Instance`) |
+| Guest, zero imports | 009: `guest/src/lib.rs`, `wasm32-unknown-unknown`, `#[no_mangle] extern "C" fn transform(i64) -> i64` | Nothing to wire — the entire point of this variant |
+| Guest, full WASI command | 011: `guest/src/main.rs`, `wasm32-wasip1`, plain `std::io::stdin()` | Compiles straight through to real `fd_read` calls — no special handling on the guest side at all |
+| WASI wiring (011 only) | `host/src/main.rs` | `wasmtime_wasi::preview1::add_to_linker_sync` + `WasiCtxBuilder::inherit_stdin/stdout/stderr` — about 10 lines, registered into the `Linker` *before* instantiation |
+
+## The two sub-shapes are deliberately different
+
+- **009 — nothing to wire.** A guest with zero imports needs no linker
+  registration at all: `Instance::new(&mut store, module, &[])`. This is the floor
+  of host complexity for this archetype.
+- **011 — explicit WASI wiring.** The guest is a real WASI *command* (uses
+  `std::io::stdin()`/`println!`), so the host must register `preview1`'s
+  functions into a `Linker<WasiP1Ctx>` and build a `WasiCtx` with stdio
+  `inherit_*`'d before instantiating, then call `_start` the same way `wasmtime
+  run` does internally. This is the concrete answer to what
+  [ADR-0002](0002-archetype-browser-worker-wasi-shim.md)'s browser Worker
+  archetype cannot do: real interactive stdin isn't a WASM/WASI limitation, it's
+  a question of whether the host actually wires `fd_read` to something real.
+  **Verified genuinely interactive, not just a piped file**: a real pty
+  (`pty.openpty()` + `select()` with a timeout) sending one line at a time
+  confirmed the guest process actually *blocks* between prompts rather than
+  having had a whole canned input file available all along.
+
+## Measured, not projected
+
+| Metric | Value | Source |
+|---|---|---|
+| True cold start, first launch (external wall-clock via `time`, includes OS process launch) | **190ms** | exp 009 |
+| True cold start, second launch (OS file cache now warm) | **4ms** | exp 009 — the ~186ms gap on first launch is the OS loading cold pages, invisible to any timer started *inside* the process |
+| Warm-loop call, first iteration | 64–172µs (varies by run, includes first-call JIT lag) | exp 009 |
+| Warm-loop call, remaining 999 iterations | median 9–15µs, min 8–13µs, max 18–101µs | exp 009 |
+
+**The warm-loop number needs its caveat stated, not just its headline quoted.**
+A Medium article claiming "~200µs average" for a comparable Go+`wazero`
+architecture is beaten here by roughly 13x — but two real, separate reasons, not
+one: (1) different engines/languages — `wasmtime` (Cranelift-JIT, zero FFI/cgo tax
+since host and engine are both Rust) vs. `wazero` (a pure-Go reimplementation, a
+different and younger compiler pipeline); (2) **this benchmark's payload does
+zero data marshalling** — `transform(i64) -> i64`, no memory access at all — while
+the article's own workload crosses the boundary with real bytes (`malloc`, write
+into WASM memory, call, read back out). [ADR-0003](0003-archetype-custom-hand-rolled-abi.md)'s
+handle-based string marshalling already shows that cost is real and not free.
+This number isolates pure call overhead, not realistic call-with-data overhead —
+presenting it as an unqualified "Rust beats Go by 13x" would be dishonest.
+
+## Constraints this archetype imposes
+
+- The host is no longer "ship a script, run anywhere" — it's a compiled, deployed
+  native binary with a real build/release story of its own.
+- If the guest needs WASI, the host must wire it explicitly — there is no
+  ambient environment providing it, unlike a real terminal running a native
+  program directly.
+- Everything is in-process: a guest fault is a fault in your host process too
+  (no subprocess/HTTP boundary absorbing it) unless you deliberately sandbox
+  further (Wasmtime's own memory isolation still applies at the WASM level, but
+  there's no OS-process isolation between host and guest here).
+
+## When this is the right shape
+
+Latency-sensitive, high-frequency calls where µs-scale overhead actually matters,
+or — uniquely among this repo's archetypes — a program that needs **real**
+interactive I/O under WASM. The cost is giving up the deployment simplicity of a
+static page ([ADR-0002](0002-archetype-browser-worker-wasi-shim.md)) or an
+off-the-shelf server CLI ([ADR-0004](0004-archetype-prebuilt-server-http-blackbox.md))
+for a bespoke native binary you now own end to end.

--- a/.openspec/adr/0006-archetype-interpreter-in-wasm.md
+++ b/.openspec/adr/0006-archetype-interpreter-in-wasm.md
@@ -1,0 +1,96 @@
+# Archetype: Interpreter-in-WASM (Ship the Runtime, Not the Program)
+
+> Exemplified by: [experiment 001](../../experiments/001_hello_world/)'s legs
+> 2a/2b/2c, [002](../../experiments/002_chromium_sandbox/)'s full 8-leg matrix,
+> and [007](../../experiments/007_custom_runtime_vs_interpreter/)'s Pyodide leg
+> (reusing 001's leg2a in place).
+
+## System Context
+
+The compiled `.wasm` is not your program — it's an entire **language runtime**
+(Pyodide: CPython compiled to WASM). Your actual code is source text, fed to the
+interpreter *at request time*, and never itself crosses a WASM import boundary.
+This is the only archetype in the repo where the guest/host ABI question doesn't
+really apply, because there's no compile-your-program-to-WASM step at all.
+
+```mermaid
+flowchart TB
+    client(["HTTP client"])
+
+    subgraph sys["System: interpreter-in-WASM, host varies by isolation strategy"]
+        direction TB
+        harness["Host harness<br/>(Node process, or headless Chromium via Puppeteer/Playwright)"]
+        pyodide["Pyodide<br/>(CPython compiled to WASM — a pre-built third-party blob)"]
+        source["Your actual code<br/>(Python source, loaded and run as text)"]
+    end
+
+    client -->|request| harness
+    harness -->|"pyodide.runPython(source) / page.evaluate(...)"| pyodide
+    pyodide -->|executes| source
+    source -->|result| pyodide
+    pyodide -->|result| harness
+    harness -->|response| client
+```
+
+## Containers
+
+| Container | Path | Role |
+|-----------|------|------|
+| Host harness | 001 leg2a: plain Node.js. 001 leg2b/2c, 002: headless Chromium (Puppeteer or Playwright) | Loads Pyodide (from disk or CDN) and feeds it source; for the browser variants, Node's own harness is itself an HTTP server the browser page talks to |
+| Pyodide | pre-built, not compiled by this repo | CPython + stdlib, compiled to WASM once by the Pyodide project |
+| Your code | plain `.py` source/modules | Interpreted, not compiled to WASM at all |
+
+## The real subject of this archetype: isolation strategy, not the interpreter itself
+
+Since the interpreter is a fixed, pre-built cost, this archetype's interesting
+findings are all about **how you isolate concurrent requests** against it — that
+is [experiment 002](../../experiments/002_chromium_sandbox/)'s entire scope, a
+2×4 matrix of {workload} × {shared page vs. isolated/pooled contexts}:
+
+| Comparison | Cold start | RSS | Warm p50 | Throughput |
+|---|---|---|---|---|
+| Shared page vs. fresh `BrowserContext`/request (CPU-bound) | 2,257ms vs 5,583ms | 593MB vs 1,791MB | 1.0ms vs 1.3ms | 920 vs 2,922 req/s (**3.2x**, fresh contexts win here — parallelism) |
+| Shared page vs. fresh context (JSON transform) | 1,685ms vs 1,659ms | 586MB vs 350MB | 0.6ms vs **946ms** | 1,604 vs 1 req/s (**fresh context is ~1,600x slower** — Pyodide reload dominates) |
+| Shared page vs. fresh context (DB query) | 1,790ms vs 1,619ms | 595MB vs 330MB | 1.1ms vs 982ms | 697 vs 1 req/s |
+| Naive vs. pooled (mixed workload) | 1,805ms vs 5,627ms | 594MB vs 1,451MB | 1.5ms vs 2.4ms | 554 vs 1,455 req/s (**2.6x**, pooling recovers throughput) |
+
+All figures are exp 002's own measured numbers, not projections. The pattern is
+consistent: a **fresh** Pyodide instance per request is catastrophic (it has to
+reload CPython from scratch — hence "~1,600x slower" on the JSON-transform
+comparison), but a **pool** of warm instances recovers most of the throughput —
+at a real, measured memory cost: **5 pooled `BrowserContext`s use ~1.7GB total
+(~340MB/context, not the ~50MB/context a naive estimate assumed)**, an explicit
+refutation logged in exp 002's own results, not a rounding footnote.
+
+## Weight, compared directly against the cheapest alternative in this repo
+
+| | Artifact | Cold start |
+|---|---|---|
+| Pyodide (this archetype) | **11.9MB** (core + stdlib zip) | 845ms |
+| [ADR-0003](0003-archetype-custom-hand-rolled-abi.md)'s minimal custom-ABI leg, same rough job | **302 bytes** | 0.28ms |
+
+Exp 007's own phrase for the size delta: **"~39,000x smaller"**. This is the
+sharpest trade-off in the whole repo, stated plainly rather than softened: shipping
+a full language runtime buys you zero-compile-step arbitrary source execution, at
+a cost measured in megabytes and hundreds of milliseconds, versus bytes and
+fractions of a millisecond for a purpose-compiled guest.
+
+## Constraints this archetype imposes
+
+- Cold start and artifact size are dominated by the interpreter, not by your
+  program — optimizing your own code barely moves either number.
+- Concurrency needs deliberate pooling; the naive "one instance per request"
+  approach is not a scaling strategy, it's the slowest option measured (~1,600x in
+  the worst case here).
+- Pooling itself has a real, fixed memory floor (~340MB/context measured, not a
+  smaller number someone might assume) — a capacity-planning input, not
+  something to guess at.
+
+## When this is the right shape
+
+You need to run arbitrary/dynamic source you don't control at build time, or a
+compile-to-WASM toolchain for your language genuinely doesn't exist or isn't
+worth building. It is the wrong shape whenever the actual program is known ahead
+of time and could instead be compiled directly — every other archetype in this
+repo beats it on artifact size and cold start by one to several orders of
+magnitude for that case.

--- a/.openspec/adr/0007-archetype-decision-guide.md
+++ b/.openspec/adr/0007-archetype-decision-guide.md
@@ -1,0 +1,63 @@
+# Decision Guide: Choosing Among the Five Archetypes
+
+> Synthesizes [ADR-0002](0002-archetype-browser-worker-wasi-shim.md) through
+> [ADR-0006](0006-archetype-interpreter-in-wasm.md). Every number below is cited
+> in its own archetype ADR, traceable to a specific experiment's README — nothing
+> here is a new measurement.
+
+## The five, in one table
+
+| Archetype | ADR | Host | Guest target | Real stdin? | Cheapest measured artifact | Cheapest measured cold start |
+|---|---|---|---|---|---|---|
+| Browser Worker + WASI shim | [0002](0002-archetype-browser-worker-wasi-shim.md) | Static page + Web Worker | `wasm32-wasip1` | No (emulated syscalls, no terminal) | 39.4KB | 22.7ms (median) |
+| Custom hand-rolled ABI | [0003](0003-archetype-custom-hand-rolled-abi.md) | Any JS host (browser or Node, same shape) | `wasm32-unknown-unknown` or MVL's backend | No — 008 wires WASI for stdout/stderr only; MVL's backend has no `fd_read` path at all | **302 bytes** | **0.28ms** |
+| Pre-built server / HTTP black box | [0004](0004-archetype-prebuilt-server-http-blackbox.md) | `wasmtime serve` / `spin up` (off-the-shelf) | `wasi:http/incoming-handler` component | N/A (HTTP, not a terminal) | not yet measured (001/003 both "results pending") | not yet measured |
+| Embedded runtime as a library | [0005](0005-archetype-embedded-runtime-library.md) | Native binary linking `wasmtime` | `wasm32-unknown-unknown` or `wasm32-wasip1` | **Yes — the only archetype proven genuinely interactive** | N/A (not artifact-size focused) | 4ms warm-cache / 190ms true cold |
+| Interpreter-in-WASM | [0006](0006-archetype-interpreter-in-wasm.md) | Node, or headless Chromium | N/A — ships CPython, not your program | No (source, not a terminal session) | 11.9MB | 845ms |
+
+## All 11 experiments, mapped
+
+| # | Name | Archetype(s) |
+|---|---|---|
+| 001 | hello_world | Leg1: plain container (control, not WASM). Leg2a/2b/2c: [0006](0006-archetype-interpreter-in-wasm.md). Leg3/4c: [0004](0004-archetype-prebuilt-server-http-blackbox.md). Leg4a: control. Leg4b: 0006 variant with a DB bridge. |
+| 002 | chromium_sandbox | [0006](0006-archetype-interpreter-in-wasm.md) — the isolation-strategy deep dive |
+| 003 | wasm_compile | [0004](0004-archetype-prebuilt-server-http-blackbox.md), all 5 legs (js-spin, py-raw, py-spin, rust, as-hello) |
+| 004 | static_wasi_hello | [0002](0002-archetype-browser-worker-wasi-shim.md) |
+| 005 | stdout_capture_load | [0002](0002-archetype-browser-worker-wasi-shim.md) |
+| 006 | worker_kill_switch | [0002](0002-archetype-browser-worker-wasi-shim.md) |
+| 007 | custom_runtime_vs_interpreter | `custom_runtime` leg: [0003](0003-archetype-custom-hand-rolled-abi.md). `componentize-py` leg: [0004](0004-archetype-prebuilt-server-http-blackbox.md) (failed — version skew, reported honestly). Pyodide leg: [0006](0006-archetype-interpreter-in-wasm.md) |
+| 008 | mvl_example_wasm_harness | [0003](0003-archetype-custom-hand-rolled-abi.md) — hybrid with real WASI stdio |
+| 009 | rust_native_host | [0005](0005-archetype-embedded-runtime-library.md) — zero-import variant |
+| 010 | mastermind_web | [0003](0003-archetype-custom-hand-rolled-abi.md) — pure library variant |
+| 011 | mastermind_cli_wasi | [0005](0005-archetype-embedded-runtime-library.md) — full WASI command variant |
+
+## Decision flow
+
+```mermaid
+flowchart TD
+    start(["What does the guest need?"]) --> q1{"Does it need to run<br/>arbitrary/dynamic source<br/>you don't control at build time?"}
+    q1 -->|yes| a6["Interpreter-in-WASM (0006)<br/>accept MB-scale artifacts,<br/>~1s cold starts, pool for concurrency"]
+    q1 -->|"no — the program is known ahead of time"| q2{"Does it need REAL<br/>interactive stdin,<br/>or microsecond-scale<br/>call latency?"}
+    q2 -->|yes| a5["Embedded runtime as a library (0005)<br/>you own a native host binary now"]
+    q2 -->|no| q3{"Must it run with<br/>ZERO backend process<br/>at request time?"}
+    q3 -->|yes| a2["Browser Worker + WASI shim (0002)<br/>wasm32-wasip1 only, no real stdin"]
+    q3 -->|no| q4{"Do multiple languages/teams<br/>need one interchangeable<br/>HTTP interface?"}
+    q4 -->|yes| a4["Pre-built server / HTTP black box (0004)<br/>watch for component-model version skew"]
+    q4 -->|no| a3["Custom hand-rolled ABI (0003)<br/>smallest footprint, but YOU own<br/>the memory-safety contract"]
+```
+
+## The one cross-cutting lesson
+
+Every archetype except [0006](0006-archetype-interpreter-in-wasm.md) (which sidesteps
+the question entirely by not compiling the guest's own code at all) puts a real
+weight-bearing wall between guest and host: a WASI shim (0002), a hand-rolled ABI
+(0003), a Component Model world (0004), or an explicitly-wired `WasiCtx` (0005).
+**This repo found three genuinely shipped, previously-undetected memory-safety
+bugs at exactly one of those walls** — the custom-ABI boundary in
+[0003](0003-archetype-custom-hand-rolled-abi.md) — and one of them had already
+been misfiled as a compiler defect before being traced back to the wall itself.
+No archetype here is free of that risk class; 0003 is simply the one with no
+framework standing between a mistake and a shipped bug. Choosing an archetype is
+partly a question of who is willing to own that wall: a browser vendor's WASI
+implementation, the Bytecode Alliance's component tooling, `wasmtime`'s own
+crate — or you.

--- a/.openspec/adr/index.md
+++ b/.openspec/adr/index.md
@@ -1,0 +1,20 @@
+# ADR Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-c4-experiment-001-hello-world.md) | C4 context — experiment 001 hello world benchmark | Accepted |
+| [0002](0002-archetype-browser-worker-wasi-shim.md) | Archetype — browser Worker + vendored WASI shim | Accepted |
+| [0003](0003-archetype-custom-hand-rolled-abi.md) | Archetype — custom hand-rolled import namespace (non-WASI ABI) | Accepted |
+| [0004](0004-archetype-prebuilt-server-http-blackbox.md) | Archetype — pre-built server consumed as an HTTP black box | Accepted |
+| [0005](0005-archetype-embedded-runtime-library.md) | Archetype — embedded runtime as a library (in-process, native host) | Accepted |
+| [0006](0006-archetype-interpreter-in-wasm.md) | Archetype — interpreter-in-WASM (ship the runtime, not the program) | Accepted |
+| [0007](0007-archetype-decision-guide.md) | Decision guide — choosing among the five archetypes | Accepted |
+
+ADRs 0002–0006 each document one recurring architecture observed across this repo's
+11 experiments — not a single decision made once, but a *shape* that keeps
+reappearing, with the trade-offs each occurrence actually measured. 0007 ties them
+together into one comparison. 0001 predates this numbering scheme (a per-experiment
+prompt-contract C4 doc, a different genre — kept as-is, not renumbered).
+
+See `.openspec/research.md` for underlying WASM/WASI specification research (a
+separate, actively-updated document, not an ADR).


### PR DESCRIPTION
## Summary

- Studied all 11 experiments and found five genuinely recurring host/ABI shapes, not eleven one-off designs. Re-verified experiments 001-007 directly from source (via a research fork) rather than relying on summarized memory.
- Added ADRs 0002-0006, one per archetype, each with a C4-style Context/Container diagram (mermaid flowchart/subgraph, not mermaid's native C4 diagram type — more reliable GitHub rendering) and only verified, cited numbers from each experiment's own README.
- ADR 0007 ties them together: comparison table, all 11 experiments mapped to an archetype, a decision flowchart, and one cross-cutting lesson (the real memory-safety bugs found this session all live at archetype 0003's hand-rolled-ABI boundary).
- Added `.openspec/adr/index.md` (the convention already used across `mvl-lang/*` repos) since this is now 8 ADRs, not 1.

## The five archetypes

| ADR | Archetype | Experiments |
|---|---|---|
| 0002 | Browser Worker + vendored WASI shim | 004, 005, 006 |
| 0003 | Custom hand-rolled import namespace | 007 (custom_runtime leg), 008, 010 |
| 0004 | Pre-built server as an HTTP black box | 001 leg3, 003's 5 legs |
| 0005 | Embedded runtime as a library (in-process) | 009, 011's host/ |
| 0006 | Interpreter-in-WASM | 001's 2a/2b/2c, 002, 007's pyodide leg |

## Found along the way (flagged, not fixed here — out of scope for a docs change)

Experiment 003's own README has real drift: it still describes now-stale symlinks (`../001_hello_world/lib` — actually `../shared/lib` since PR #20) and doesn't mention a 5th, undocumented AssemblyScript leg (`as-hello/`) that exists on disk and is wired into the Makefile/bats suite.

## Testing

- [x] Every cross-reference link (to other ADRs and to experiment directories) verified to resolve on disk
- [x] Every mermaid diagram's edge labels with special characters (parens, commas, colons) double-quoted defensively
- [x] Every cited number spot-checked against its source README, not just trusted from the research fork's report

No CI configured in this repo, merging directly once reviewed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>