### PR TITLE
chore(deps): bump wasmtime 27 -> 47 in 009 and 011 host crates

### DIFF
--- a/experiments/009_rust_native_host/host/Cargo.toml
+++ b/experiments/009_rust_native_host/host/Cargo.toml
@@ -8,7 +8,7 @@ name = "wasm_host"
 path = "src/main.rs"
 
 [dependencies]
-wasmtime = "27"
+wasmtime = "47"
 
 [profile.release]
 opt-level = 3

--- a/experiments/011_mastermind_cli_wasi/host/Cargo.toml
+++ b/experiments/011_mastermind_cli_wasi/host/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.104"
-wasmtime = "27"
-wasmtime-wasi = "27"
+wasmtime = "47"
+wasmtime-wasi = "47"

--- a/experiments/011_mastermind_cli_wasi/host/src/main.rs
+++ b/experiments/011_mastermind_cli_wasi/host/src/main.rs
@@ -9,7 +9,7 @@
 // few lines: a WasiCtx with stdio inherited, wired into a Linker before
 // instantiation.
 use wasmtime::{Config, Engine, Linker, Module, Store};
-use wasmtime_wasi::preview1::{self, WasiP1Ctx};
+use wasmtime_wasi::p1::{self, WasiP1Ctx};
 use wasmtime_wasi::WasiCtxBuilder;
 
 const WASM_PATH: &str = concat!(
@@ -28,9 +28,9 @@ fn main() -> anyhow::Result<()> {
     // everything Rust's std::io::stdin() compiles down to) resolves to a
     // real implementation instead of an unsatisfied import. wasm32-wasip1
     // (this guest's target) uses the "preview1" flat-ABI WASI, not the
-    // component-model preview2 — hence `preview1::add_to_linker_sync`, not
+    // component-model preview2 — hence `p1::add_to_linker_sync`, not
     // the crate-root `add_to_linker_sync` (which is preview2/component-only).
-    preview1::add_to_linker_sync(&mut linker, |ctx| ctx)?;
+    p1::add_to_linker_sync(&mut linker, |ctx| ctx)?;
 
     // inherit_stdin()/inherit_stdout()/inherit_stderr(): the guest's fd 0/1/2
     // are wired directly to THIS process's real stdio — genuine fd_read
@@ -59,7 +59,7 @@ fn main() -> anyhow::Result<()> {
             if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
                 std::process::exit(exit.0);
             }
-            Err(e)
+            Err(e.into())
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bumps `wasmtime` 27 -> 47 in `experiments/009_rust_native_host/host` (bare embedding API, no code changes needed) and `wasmtime`/`wasmtime-wasi` 27 -> 47 in `experiments/011_mastermind_cli_wasi/host`.
- `wasmtime_wasi::preview1` was renamed to `wasmtime_wasi::p1` somewhere in that version range; `WasiCtxBuilder`/linker methods (`build_p1()`, `add_to_linker_sync`, `inherit_stdin/stdout/stderr`) are unchanged.
- `wasmtime::Error` is no longer a re-export of `anyhow::Error`, so the WASI exit-trap `Err(e)` needed `.into()`.

## Test plan
- [x] `cargo build --release` clean in both `host/` crates
- [x] `make build` + `make test` pass in `009_rust_native_host` (`--single-shot`/`--loop` modes)
- [x] `make build` + `make test` pass in `011_mastermind_cli_wasi` (piped-stdin Mastermind session via the embedded host)
- [x] Confirmed the guest `.wasm` itself is untouched by running it directly under the system `wasmtime` CLI (43.0.1)