### PR TITLE
feat: add experiments 012 (stdlib size) and 013 (unicode strategies)

### DIFF
--- a/experiments/012_stdlib_size_matrix/README.md
+++ b/experiments/012_stdlib_size_matrix/README.md
@@ -1,0 +1,120 @@
+# Experiment 012 — Stdlib Size Matrix
+
+Measures how different WASM optimization strategies affect binary size when a
+small application calls into a larger stdlib library.
+
+## Motivation
+
+WASM binaries carrying a full stdlib can grow large. This experiment explores
+the size trade-offs between:
+
+1. **Link-time optimization (LTO)** — whole-program dead code elimination
+2. **wasm-opt -Oz** — Binaryen's size-focused optimizer
+3. **wasm-merge** — multi-module linking for deferred/lazy stdlib loading
+4. **Feature flags** — compile-time stdlib subsetting (only include what you use)
+
+## Structure
+
+```
+012_stdlib_size_matrix/
+├── app/                    # Small Rust program (Mastermind-inspired)
+│   ├── Cargo.toml
+│   └── src/lib.rs
+├── stdlib/                 # Larger "stdlib" with many functions
+│   ├── Cargo.toml
+│   └── src/lib.rs
+├── legs/
+│   ├── leg1_baseline/      # No optimization
+│   ├── leg2_lto/           # LTO only
+│   ├── leg3_wasm_opt/      # wasm-opt -Oz only
+│   ├── leg4_lto_wasm_opt/  # LTO + wasm-opt -Oz
+│   ├── leg5_feature_flags/ # Feature-gated stdlib
+│   └── leg6_wasm_merge/    # Split modules, merged at load time
+├── build.sh                # Build all legs
+├── benchmark.sh            # Measure sizes
+└── README.md
+```
+
+## Hypotheses
+
+| # | Hypothesis | Status |
+|---|-----------|--------|
+| H1 | **LTO alone** removes ~30-50% of dead stdlib code | — |
+| H2 | **wasm-opt -Oz** adds another ~10-20% reduction on top of LTO | — |
+| H3 | **Feature flags** give the smallest binary (only compile what's used) | — |
+| H4 | **wasm-merge** defers stdlib loading but total download ≈ monolithic | — |
+
+## The App
+
+A simplified Mastermind scorer translated from MVL to Rust. Uses stdlib for:
+- String manipulation (parsing guesses)
+- Random number generation (secret code)
+- List/Vec operations (scoring)
+- Optional: Unicode string functions
+
+```rust
+// Pseudocode — actual impl in app/src/lib.rs
+fn score_guess(secret: &[u8], guess: &[u8]) -> (u8, u8) {
+    // blacks: exact matches, whites: color-only matches
+}
+
+fn parse_guess(input: &str) -> Option<Vec<u8>> {
+    // Parse "1 2 3 4" into [1, 2, 3, 4]
+}
+```
+
+## The Stdlib
+
+A kitchen-sink library mimicking what a real stdlib might include. Large enough
+that dead code elimination is meaningful:
+
+- **strings**: len, concat, split, trim, to_upper, to_lower, find, substring
+- **unicode**: char_at, chars, is_whitespace, is_alphanumeric, normalize
+- **collections**: map, filter, fold, zip, flatten, sort, dedup, reverse
+- **math**: sqrt, pow, log, sin, cos, tan, abs, min, max, clamp
+- **random**: int_range, float, bytes, shuffle, choice
+- **time**: now, sleep, format_iso8601
+- **io**: (stubs) read_file, write_file, exists
+- **json**: (stubs) parse, stringify
+
+Feature flags control which modules are compiled:
+- `full` — everything (default)
+- `strings` — string ops only
+- `unicode` — strings + unicode
+- `collections` — vec/list ops
+- `math` — numeric functions
+- `all-no-unicode` — everything except unicode tables
+
+## Results
+
+*Run `./benchmark.sh` to populate.*
+
+| Leg | Strategy | .wasm size | gzip size | Notes |
+|-----|----------|-----------|-----------|-------|
+| 1 | baseline (debug) | | | |
+| 2 | release + LTO | | | |
+| 3 | release + wasm-opt -Oz | | | |
+| 4 | release + LTO + wasm-opt -Oz | | | |
+| 5 | feature flags (strings only) | | | |
+| 6 | wasm-merge (split modules) | | | |
+
+## Running
+
+```bash
+# Build all legs
+./build.sh
+
+# Run size benchmark
+./benchmark.sh
+
+# Build specific leg
+cd legs/leg2_lto && ./build.sh
+```
+
+## Prerequisites
+
+```bash
+rustup target add wasm32-wasip1
+cargo install wasm-opt       # Binaryen
+cargo install wasm-merge     # wasmtime tools (or build from source)
+```

--- a/experiments/012_stdlib_size_matrix/app/Cargo.toml
+++ b/experiments/012_stdlib_size_matrix/app/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mastermind-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mvl-stdlib = { path = "../stdlib", default-features = false, features = ["strings", "random", "collections"] }
+
+[profile.release]
+opt-level = "z"
+lto = false  # Controlled per-leg

--- a/experiments/012_stdlib_size_matrix/app/src/lib.rs
+++ b/experiments/012_stdlib_size_matrix/app/src/lib.rs
@@ -1,0 +1,298 @@
+//! Mastermind game logic for WASM.
+//!
+//! A simplified port of mvl-lang/mvl/examples/mastermind to Rust.
+//! Uses the stdlib for string parsing and random number generation.
+
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use mvl_stdlib::random;
+use mvl_stdlib::strings;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Types
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Scoring result for one guess.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Feedback {
+    pub blacks: u8,
+    pub whites: u8,
+}
+
+/// Outcome of parsing a guess line.
+pub enum GuessResult {
+    Guess(Vec<u8>),
+    Invalid,
+    Empty,
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Game Logic
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Generate a random secret code of 4 colors (1-6).
+pub fn generate_secret() -> Vec<u8> {
+    alloc::vec![
+        random::int_range(1, 6) as u8,
+        random::int_range(1, 6) as u8,
+        random::int_range(1, 6) as u8,
+        random::int_range(1, 6) as u8,
+    ]
+}
+
+/// Count positions where guess matches secret exactly.
+fn count_blacks(secret: &[u8], guess: &[u8]) -> u8 {
+    let mut n = 0u8;
+    for i in 0..secret.len().min(guess.len()) {
+        if secret[i] == guess[i] {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// Count occurrences of `color` in `xs` at positions where `xs[i] != other[i]`.
+fn count_color_at_mismatch(xs: &[u8], other: &[u8], color: u8) -> u8 {
+    let mut n = 0u8;
+    for i in 0..xs.len().min(other.len()) {
+        if xs[i] == color && xs[i] != other[i] {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// Score `guess` against `secret` (classic Mastermind rules).
+pub fn score_guess(secret: &[u8], guess: &[u8]) -> Feedback {
+    let blacks = count_blacks(secret, guess);
+    let mut whites = 0u8;
+    for color in 1..=6 {
+        let in_secret = count_color_at_mismatch(secret, guess, color);
+        let in_guess = count_color_at_mismatch(guess, secret, color);
+        whites += in_secret.min(in_guess);
+    }
+    Feedback { blacks, whites }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Parsing
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Parse a guess line like "1 2 3 4" into a code.
+pub fn parse_guess(input: &str) -> GuessResult {
+    let trimmed = strings::trim(input);
+    if strings::is_empty(trimmed) {
+        return GuessResult::Empty;
+    }
+
+    let parts = strings::split(trimmed, " ");
+    let non_empty: Vec<&str> = parts.into_iter().filter(|s| !s.is_empty()).collect();
+
+    if non_empty.len() != 4 {
+        return GuessResult::Invalid;
+    }
+
+    let mut code = Vec::with_capacity(4);
+    for part in non_empty {
+        match strings::parse_int(part) {
+            Some(n) if n >= 1 && n <= 6 => code.push(n as u8),
+            _ => return GuessResult::Invalid,
+        }
+    }
+
+    GuessResult::Guess(code)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Display
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Display name for a color number (1-6).
+pub fn color_name(n: u8) -> &'static str {
+    match n {
+        1 => "red",
+        2 => "green",
+        3 => "blue",
+        4 => "yellow",
+        5 => "orange",
+        6 => "purple",
+        _ => "?",
+    }
+}
+
+/// Render a code as e.g. "red green blue yellow".
+pub fn render_code(code: &[u8]) -> String {
+    let names: Vec<&str> = code.iter().map(|&n| color_name(n)).collect();
+    let mut result = String::new();
+    for (i, name) in names.iter().enumerate() {
+        if i > 0 {
+            result.push(' ');
+        }
+        result.push_str(name);
+    }
+    result
+}
+
+/// Render scoring feedback as e.g. "blacks: 2  whites: 1".
+pub fn render_feedback(fb: Feedback) -> String {
+    let mut result = String::from("blacks: ");
+    result.push((fb.blacks + b'0') as char);
+    result.push_str("  whites: ");
+    result.push((fb.whites + b'0') as char);
+    result
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// WASM Exports
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Initialize the RNG with a seed.
+#[unsafe(no_mangle)]
+pub extern "C" fn init(seed: u64) {
+    random::seed(seed);
+}
+
+/// Generate a new secret and return it as a 4-byte value.
+/// Each byte is a color 1-6.
+#[unsafe(no_mangle)]
+pub extern "C" fn new_game() -> u32 {
+    let secret = generate_secret();
+    ((secret[0] as u32) << 24)
+        | ((secret[1] as u32) << 16)
+        | ((secret[2] as u32) << 8)
+        | (secret[3] as u32)
+}
+
+/// Score a guess against a secret.
+/// Both are packed as 4-byte values.
+/// Returns (blacks << 8) | whites.
+#[unsafe(no_mangle)]
+pub extern "C" fn score(secret: u32, guess: u32) -> u16 {
+    let s = [
+        ((secret >> 24) & 0xFF) as u8,
+        ((secret >> 16) & 0xFF) as u8,
+        ((secret >> 8) & 0xFF) as u8,
+        (secret & 0xFF) as u8,
+    ];
+    let g = [
+        ((guess >> 24) & 0xFF) as u8,
+        ((guess >> 16) & 0xFF) as u8,
+        ((guess >> 8) & 0xFF) as u8,
+        (guess & 0xFF) as u8,
+    ];
+    let fb = score_guess(&s, &g);
+    ((fb.blacks as u16) << 8) | (fb.whites as u16)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Panic Handler
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// Global allocator
+#[cfg(not(test))]
+mod alloc_impl {
+    use core::alloc::{GlobalAlloc, Layout};
+
+    struct BumpAllocator;
+
+    static mut HEAP: [u8; 16384] = [0; 16384];
+    static mut HEAP_PTR: usize = 0;
+
+    unsafe impl GlobalAlloc for BumpAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let align = layout.align();
+            let size = layout.size();
+            let ptr = HEAP_PTR;
+            let aligned = (ptr + align - 1) & !(align - 1);
+            let new_ptr = aligned + size;
+            if new_ptr > HEAP.len() {
+                core::ptr::null_mut()
+            } else {
+                HEAP_PTR = new_ptr;
+                HEAP.as_mut_ptr().add(aligned)
+            }
+        }
+
+        unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+            // Bump allocator doesn't deallocate
+        }
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: BumpAllocator = BumpAllocator;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_score_all_correct() {
+        let fb = score_guess(&[1, 2, 3, 4], &[1, 2, 3, 4]);
+        assert_eq!(fb, Feedback { blacks: 4, whites: 0 });
+    }
+
+    #[test]
+    fn test_score_all_wrong_position() {
+        let fb = score_guess(&[1, 2, 3, 4], &[4, 3, 2, 1]);
+        assert_eq!(fb, Feedback { blacks: 0, whites: 4 });
+    }
+
+    #[test]
+    fn test_score_mixed() {
+        let fb = score_guess(&[1, 2, 3, 4], &[1, 3, 2, 5]);
+        assert_eq!(fb, Feedback { blacks: 1, whites: 2 });
+    }
+
+    #[test]
+    fn test_score_with_repeats() {
+        let fb = score_guess(&[1, 1, 2, 2], &[1, 2, 1, 2]);
+        assert_eq!(fb, Feedback { blacks: 2, whites: 2 });
+    }
+
+    #[test]
+    fn test_parse_valid() {
+        match parse_guess("1 2 3 4") {
+            GuessResult::Guess(code) => assert_eq!(code, vec![1, 2, 3, 4]),
+            _ => panic!("Expected valid guess"),
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid_count() {
+        match parse_guess("1 2 3") {
+            GuessResult::Invalid => {}
+            _ => panic!("Expected invalid"),
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid_range() {
+        match parse_guess("1 2 3 7") {
+            GuessResult::Invalid => {}
+            _ => panic!("Expected invalid"),
+        }
+    }
+
+    #[test]
+    fn test_parse_empty() {
+        match parse_guess("   ") {
+            GuessResult::Empty => {}
+            _ => panic!("Expected empty"),
+        }
+    }
+}

--- a/experiments/012_stdlib_size_matrix/benchmark.sh
+++ b/experiments/012_stdlib_size_matrix/benchmark.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Benchmark WASM sizes for stdlib experiment.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+OUT=output
+
+if [ ! -d "$OUT" ] || [ -z "$(ls -A "$OUT"/*.wasm 2>/dev/null)" ]; then
+    echo "No WASM files found. Run ./build.sh first."
+    exit 1
+fi
+
+echo "=== Experiment 012: Stdlib Size Benchmark ==="
+echo ""
+printf "%-25s %10s %10s %10s\n" "Leg" ".wasm" "gzip" "brotli"
+printf "%-25s %10s %10s %10s\n" "---" "-----" "----" "------"
+
+for wasm in "$OUT"/*.wasm; do
+    name=$(basename "$wasm" .wasm)
+    size=$(wc -c < "$wasm" | tr -d ' ')
+
+    # gzip size
+    gzip_size=$(gzip -c "$wasm" | wc -c | tr -d ' ')
+
+    # brotli size (if available)
+    if command -v brotli &>/dev/null; then
+        brotli_size=$(brotli -c "$wasm" | wc -c | tr -d ' ')
+    else
+        brotli_size="-"
+    fi
+
+    printf "%-25s %10s %10s %10s\n" "$name" "$size" "$gzip_size" "$brotli_size"
+done
+
+echo ""
+echo "Sizes in bytes. Lower is better."
+echo ""
+
+# Show relative comparisons
+if [ -f "$OUT/leg1_baseline.wasm" ] && [ -f "$OUT/leg4_lto_wasm_opt.wasm" ]; then
+    baseline=$(wc -c < "$OUT/leg1_baseline.wasm" | tr -d ' ')
+    optimized=$(wc -c < "$OUT/leg4_lto_wasm_opt.wasm" | tr -d ' ')
+    reduction=$((100 - (optimized * 100 / baseline)))
+    echo "LTO + wasm-opt -Oz reduces baseline by ${reduction}%"
+fi
+
+if [ -f "$OUT/leg4_lto_wasm_opt.wasm" ] && [ -f "$OUT/leg5_minimal.wasm" ]; then
+    full=$(wc -c < "$OUT/leg4_lto_wasm_opt.wasm" | tr -d ' ')
+    minimal=$(wc -c < "$OUT/leg5_minimal.wasm" | tr -d ' ')
+    reduction=$((100 - (minimal * 100 / full)))
+    echo "Feature flags (strings only) reduces by ${reduction}% vs full"
+fi

--- a/experiments/012_stdlib_size_matrix/build.sh
+++ b/experiments/012_stdlib_size_matrix/build.sh
@@ -1,0 +1,323 @@
+#!/bin/bash
+# Build all legs of the stdlib size experiment.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "=== Building Experiment 012: Stdlib Size Matrix ==="
+
+# Ensure target is available
+rustup target add wasm32-unknown-unknown 2>/dev/null || true
+
+# Check for wasm-opt
+if ! command -v wasm-opt &>/dev/null; then
+    echo "Warning: wasm-opt not found. Install with: cargo install wasm-opt"
+    echo "Legs 3/4 will be skipped."
+    HAS_WASM_OPT=0
+else
+    HAS_WASM_OPT=1
+fi
+
+OUT=output
+mkdir -p "$OUT"
+
+# ─── Leg 1: Baseline (debug) ───────────────────────────────────────────────────
+
+echo ""
+echo "Leg 1: Baseline (no optimization)..."
+cargo build --manifest-path app/Cargo.toml --target wasm32-unknown-unknown
+cp target/wasm32-unknown-unknown/debug/mastermind_wasm.wasm "$OUT/leg1_baseline.wasm"
+
+# ─── Leg 2: Release + LTO ──────────────────────────────────────────────────────
+
+echo ""
+echo "Leg 2: Release + LTO..."
+
+# Create a temporary Cargo.toml with LTO enabled
+cat > app/Cargo.toml.leg2 << 'EOF'
+[package]
+name = "mastermind-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mvl-stdlib = { path = "../stdlib", default-features = false, features = ["strings", "random", "collections"] }
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+EOF
+
+mv app/Cargo.toml app/Cargo.toml.bak
+mv app/Cargo.toml.leg2 app/Cargo.toml
+
+cargo build --manifest-path app/Cargo.toml --target wasm32-unknown-unknown --release
+cp target/wasm32-unknown-unknown/release/mastermind_wasm.wasm "$OUT/leg2_lto.wasm"
+
+mv app/Cargo.toml.bak app/Cargo.toml
+
+# ─── Leg 3: Release + wasm-opt -Oz ─────────────────────────────────────────────
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    echo ""
+    echo "Leg 3: Release + wasm-opt -Oz..."
+
+    cargo build --manifest-path app/Cargo.toml --target wasm32-unknown-unknown --release
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/mastermind_wasm.wasm -o "$OUT/leg3_wasm_opt.wasm"
+fi
+
+# ─── Leg 4: Release + LTO + wasm-opt -Oz ───────────────────────────────────────
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    echo ""
+    echo "Leg 4: Release + LTO + wasm-opt -Oz..."
+
+    # Use LTO config
+    mv app/Cargo.toml app/Cargo.toml.bak
+    cat > app/Cargo.toml << 'EOF'
+[package]
+name = "mastermind-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mvl-stdlib = { path = "../stdlib", default-features = false, features = ["strings", "random", "collections"] }
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+EOF
+
+    cargo build --manifest-path app/Cargo.toml --target wasm32-unknown-unknown --release
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/mastermind_wasm.wasm -o "$OUT/leg4_lto_wasm_opt.wasm"
+
+    mv app/Cargo.toml.bak app/Cargo.toml
+fi
+
+# ─── Leg 5: Feature flags (strings only) ───────────────────────────────────────
+
+echo ""
+echo "Leg 5: Minimal features (strings only)..."
+
+# Create minimal app that only uses strings
+cat > app/Cargo.toml.leg5 << 'EOF'
+[package]
+name = "mastermind-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mvl-stdlib = { path = "../stdlib", default-features = false, features = ["strings"] }
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+EOF
+
+# Create minimal lib.rs that doesn't use random
+cat > app/src/lib.rs.leg5 << 'EOF'
+//! Minimal Mastermind (no random) for size comparison.
+
+#![no_std]
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use mvl_stdlib::strings;
+
+/// Scoring result for one guess.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Feedback {
+    pub blacks: u8,
+    pub whites: u8,
+}
+
+/// Count positions where guess matches secret exactly.
+fn count_blacks(secret: &[u8], guess: &[u8]) -> u8 {
+    let mut n = 0u8;
+    for i in 0..secret.len().min(guess.len()) {
+        if secret[i] == guess[i] {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// Count occurrences of `color` in `xs` at positions where `xs[i] != other[i]`.
+fn count_color_at_mismatch(xs: &[u8], other: &[u8], color: u8) -> u8 {
+    let mut n = 0u8;
+    for i in 0..xs.len().min(other.len()) {
+        if xs[i] == color && xs[i] != other[i] {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// Score `guess` against `secret`.
+pub fn score_guess(secret: &[u8], guess: &[u8]) -> Feedback {
+    let blacks = count_blacks(secret, guess);
+    let mut whites = 0u8;
+    for color in 1..=6 {
+        let in_secret = count_color_at_mismatch(secret, guess, color);
+        let in_guess = count_color_at_mismatch(guess, secret, color);
+        whites += in_secret.min(in_guess);
+    }
+    Feedback { blacks, whites }
+}
+
+/// Parse a guess line like "1 2 3 4" into a code.
+pub fn parse_guess(input: &str) -> Option<Vec<u8>> {
+    let trimmed = strings::trim(input);
+    if strings::is_empty(trimmed) {
+        return None;
+    }
+
+    let parts = strings::split(trimmed, " ");
+    let non_empty: Vec<&str> = parts.into_iter().filter(|s| !s.is_empty()).collect();
+
+    if non_empty.len() != 4 {
+        return None;
+    }
+
+    let mut code = Vec::with_capacity(4);
+    for part in non_empty {
+        match strings::parse_int(part) {
+            Some(n) if n >= 1 && n <= 6 => code.push(n as u8),
+            _ => return None,
+        }
+    }
+
+    Some(code)
+}
+
+/// Score a guess against a secret.
+#[unsafe(no_mangle)]
+pub extern "C" fn score(secret: u32, guess: u32) -> u16 {
+    let s = [
+        ((secret >> 24) & 0xFF) as u8,
+        ((secret >> 16) & 0xFF) as u8,
+        ((secret >> 8) & 0xFF) as u8,
+        (secret & 0xFF) as u8,
+    ];
+    let g = [
+        ((guess >> 24) & 0xFF) as u8,
+        ((guess >> 16) & 0xFF) as u8,
+        ((guess >> 8) & 0xFF) as u8,
+        (guess & 0xFF) as u8,
+    ];
+    let fb = score_guess(&s, &g);
+    ((fb.blacks as u16) << 8) | (fb.whites as u16)
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[cfg(not(test))]
+mod alloc_impl {
+    use core::alloc::{GlobalAlloc, Layout};
+
+    struct BumpAllocator;
+
+    static mut HEAP: [u8; 8192] = [0; 8192];
+    static mut HEAP_PTR: usize = 0;
+
+    unsafe impl GlobalAlloc for BumpAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let align = layout.align();
+            let size = layout.size();
+            let ptr = HEAP_PTR;
+            let aligned = (ptr + align - 1) & !(align - 1);
+            let new_ptr = aligned + size;
+            if new_ptr > HEAP.len() {
+                core::ptr::null_mut()
+            } else {
+                HEAP_PTR = new_ptr;
+                HEAP.as_mut_ptr().add(aligned)
+            }
+        }
+
+        unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: BumpAllocator = BumpAllocator;
+}
+EOF
+
+mv app/Cargo.toml app/Cargo.toml.bak
+mv app/src/lib.rs app/src/lib.rs.bak
+mv app/Cargo.toml.leg5 app/Cargo.toml
+mv app/src/lib.rs.leg5 app/src/lib.rs
+
+cargo build --manifest-path app/Cargo.toml --target wasm32-unknown-unknown --release
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/mastermind_wasm.wasm -o "$OUT/leg5_minimal.wasm"
+else
+    cp target/wasm32-unknown-unknown/release/mastermind_wasm.wasm "$OUT/leg5_minimal.wasm"
+fi
+
+mv app/src/lib.rs.bak app/src/lib.rs
+mv app/Cargo.toml.bak app/Cargo.toml
+
+# ─── Leg 6: Full stdlib (for reference) ────────────────────────────────────────
+
+echo ""
+echo "Leg 6: Full stdlib (all features)..."
+
+cat > app/Cargo.toml.leg6 << 'EOF'
+[package]
+name = "mastermind-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+mvl-stdlib = { path = "../stdlib", default-features = true }
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+EOF
+
+mv app/Cargo.toml app/Cargo.toml.bak
+mv app/Cargo.toml.leg6 app/Cargo.toml
+
+cargo build --manifest-path app/Cargo.toml --target wasm32-unknown-unknown --release
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/mastermind_wasm.wasm -o "$OUT/leg6_full_stdlib.wasm"
+else
+    cp target/wasm32-unknown-unknown/release/mastermind_wasm.wasm "$OUT/leg6_full_stdlib.wasm"
+fi
+
+mv app/Cargo.toml.bak app/Cargo.toml
+
+# ─── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Build Complete ==="
+echo ""
+echo "Output files in $OUT/:"
+ls -la "$OUT/"*.wasm 2>/dev/null || echo "(no wasm files)"
+
+echo ""
+echo "Run ./benchmark.sh for size analysis."

--- a/experiments/012_stdlib_size_matrix/stdlib/Cargo.toml
+++ b/experiments/012_stdlib_size_matrix/stdlib/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mvl-stdlib"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["full"]
+full = ["strings", "unicode", "collections", "math", "random", "time", "io", "json"]
+strings = []
+unicode = ["strings"]
+collections = []
+math = []
+random = []
+time = []
+io = []
+json = []
+all-no-unicode = ["strings", "collections", "math", "random", "time", "io", "json"]
+
+[dependencies]
+
+[profile.release]
+opt-level = "z"
+lto = false  # Controlled per-leg

--- a/experiments/012_stdlib_size_matrix/stdlib/src/lib.rs
+++ b/experiments/012_stdlib_size_matrix/stdlib/src/lib.rs
@@ -1,0 +1,874 @@
+//! MVL-style stdlib for WASM size experiments.
+//!
+//! This is intentionally larger than needed to measure dead code elimination.
+//! Feature flags control which modules are compiled.
+
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// STRINGS MODULE
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "strings")]
+pub mod strings {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    /// String length in bytes.
+    #[inline]
+    pub fn len(s: &str) -> usize {
+        s.len()
+    }
+
+    /// Concatenate two strings.
+    pub fn concat(a: &str, b: &str) -> String {
+        let mut result = String::with_capacity(a.len() + b.len());
+        result.push_str(a);
+        result.push_str(b);
+        result
+    }
+
+    /// Split string by delimiter.
+    pub fn split<'a>(s: &'a str, delim: &str) -> Vec<&'a str> {
+        s.split(delim).collect()
+    }
+
+    /// Trim whitespace from both ends.
+    pub fn trim(s: &str) -> &str {
+        s.trim()
+    }
+
+    /// ASCII uppercase (non-Unicode).
+    pub fn to_upper_ascii(s: &str) -> String {
+        s.chars()
+            .map(|c| {
+                if c >= 'a' && c <= 'z' {
+                    ((c as u8) - 32) as char
+                } else {
+                    c
+                }
+            })
+            .collect()
+    }
+
+    /// ASCII lowercase (non-Unicode).
+    pub fn to_lower_ascii(s: &str) -> String {
+        s.chars()
+            .map(|c| {
+                if c >= 'A' && c <= 'Z' {
+                    ((c as u8) + 32) as char
+                } else {
+                    c
+                }
+            })
+            .collect()
+    }
+
+    /// Find substring, returns byte offset or None.
+    pub fn find(haystack: &str, needle: &str) -> Option<usize> {
+        haystack.find(needle)
+    }
+
+    /// Extract substring by byte range.
+    pub fn substring(s: &str, start: usize, end: usize) -> &str {
+        &s[start..end.min(s.len())]
+    }
+
+    /// Check if string starts with prefix.
+    pub fn starts_with(s: &str, prefix: &str) -> bool {
+        s.starts_with(prefix)
+    }
+
+    /// Check if string ends with suffix.
+    pub fn ends_with(s: &str, suffix: &str) -> bool {
+        s.ends_with(suffix)
+    }
+
+    /// Replace all occurrences.
+    pub fn replace(s: &str, from: &str, to: &str) -> String {
+        s.replace(from, to)
+    }
+
+    /// Repeat string n times.
+    pub fn repeat(s: &str, n: usize) -> String {
+        s.repeat(n)
+    }
+
+    /// Check if string is empty.
+    #[inline]
+    pub fn is_empty(s: &str) -> bool {
+        s.is_empty()
+    }
+
+    /// Parse integer from string.
+    pub fn parse_int(s: &str) -> Option<i64> {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        let (neg, digits) = if s.starts_with('-') {
+            (true, &s[1..])
+        } else if s.starts_with('+') {
+            (false, &s[1..])
+        } else {
+            (false, s)
+        };
+        let mut result: i64 = 0;
+        for b in digits.bytes() {
+            if b < b'0' || b > b'9' {
+                return None;
+            }
+            result = result.checked_mul(10)?.checked_add((b - b'0') as i64)?;
+        }
+        if neg {
+            Some(-result)
+        } else {
+            Some(result)
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// UNICODE MODULE (adds significant size)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "unicode")]
+pub mod unicode {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    // Embedded Unicode case mapping tables (simplified - real ones are larger)
+    // This is a subset for demonstration; real tables are 50-150KB
+
+    /// Simple uppercase mapping table (code point ranges).
+    /// Format: (start, end, offset)
+    static UPPER_MAP: &[(u32, u32, i32)] = &[
+        // Latin lowercase a-z → A-Z
+        (0x0061, 0x007A, -32),
+        // Latin Extended-A (selected)
+        (0x00E0, 0x00F6, -32), // à-ö → À-Ö
+        (0x00F8, 0x00FE, -32), // ø-þ → Ø-Þ
+        // Greek lowercase
+        (0x03B1, 0x03C1, -32), // α-ρ → Α-Ρ
+        (0x03C3, 0x03C9, -32), // σ-ω → Σ-Ω
+        // Cyrillic lowercase
+        (0x0430, 0x044F, -32), // а-я → А-Я
+    ];
+
+    /// Check if character is whitespace (Unicode-aware).
+    pub fn is_whitespace(c: char) -> bool {
+        matches!(
+            c,
+            ' ' | '\t'
+                | '\n'
+                | '\r'
+                | '\x0B'
+                | '\x0C'
+                | '\u{00A0}'
+                | '\u{1680}'
+                | '\u{2000}'..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+        )
+    }
+
+    /// Check if character is alphanumeric (Unicode-aware).
+    pub fn is_alphanumeric(c: char) -> bool {
+        c.is_alphanumeric()
+    }
+
+    /// Convert character to uppercase using embedded tables.
+    pub fn char_to_upper(c: char) -> char {
+        let cp = c as u32;
+        for &(start, end, offset) in UPPER_MAP {
+            if cp >= start && cp <= end {
+                return char::from_u32((cp as i32 + offset) as u32).unwrap_or(c);
+            }
+        }
+        c
+    }
+
+    /// Convert string to uppercase (Unicode-aware).
+    pub fn to_upper(s: &str) -> String {
+        s.chars().map(char_to_upper).collect()
+    }
+
+    /// Convert character to lowercase using embedded tables.
+    pub fn char_to_lower(c: char) -> char {
+        let cp = c as u32;
+        // Inverse of UPPER_MAP
+        for &(start, end, offset) in UPPER_MAP {
+            let upper_start = (start as i32 + offset) as u32;
+            let upper_end = (end as i32 + offset) as u32;
+            if cp >= upper_start && cp <= upper_end {
+                return char::from_u32((cp as i32 - offset) as u32).unwrap_or(c);
+            }
+        }
+        c
+    }
+
+    /// Convert string to lowercase (Unicode-aware).
+    pub fn to_lower(s: &str) -> String {
+        s.chars().map(char_to_lower).collect()
+    }
+
+    /// Count Unicode characters (not bytes).
+    pub fn char_count(s: &str) -> usize {
+        s.chars().count()
+    }
+
+    /// Get character at index (0-based).
+    pub fn char_at(s: &str, idx: usize) -> Option<char> {
+        s.chars().nth(idx)
+    }
+
+    /// Get all characters as a vector.
+    pub fn chars(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+
+    /// Normalize NFC (stub - real implementation needs tables).
+    pub fn normalize_nfc(s: &str) -> String {
+        // Real NFC normalization requires large tables
+        // This is a stub that just returns the input
+        String::from(s)
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// COLLECTIONS MODULE
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "collections")]
+pub mod collections {
+    use alloc::vec::Vec;
+
+    /// Map over a vector.
+    pub fn map<T, U, F>(xs: Vec<T>, f: F) -> Vec<U>
+    where
+        F: Fn(T) -> U,
+    {
+        xs.into_iter().map(f).collect()
+    }
+
+    /// Filter a vector.
+    pub fn filter<T, F>(xs: Vec<T>, predicate: F) -> Vec<T>
+    where
+        F: Fn(&T) -> bool,
+    {
+        xs.into_iter().filter(predicate).collect()
+    }
+
+    /// Fold/reduce a vector.
+    pub fn fold<T, U, F>(xs: Vec<T>, init: U, f: F) -> U
+    where
+        F: Fn(U, T) -> U,
+    {
+        xs.into_iter().fold(init, f)
+    }
+
+    /// Zip two vectors.
+    pub fn zip<T, U>(xs: Vec<T>, ys: Vec<U>) -> Vec<(T, U)> {
+        xs.into_iter().zip(ys).collect()
+    }
+
+    /// Flatten nested vectors.
+    pub fn flatten<T>(xss: Vec<Vec<T>>) -> Vec<T> {
+        xss.into_iter().flatten().collect()
+    }
+
+    /// Sort a vector (requires Ord).
+    pub fn sort<T: Ord>(mut xs: Vec<T>) -> Vec<T> {
+        xs.sort();
+        xs
+    }
+
+    /// Remove consecutive duplicates.
+    pub fn dedup<T: PartialEq>(mut xs: Vec<T>) -> Vec<T> {
+        xs.dedup();
+        xs
+    }
+
+    /// Reverse a vector.
+    pub fn reverse<T>(mut xs: Vec<T>) -> Vec<T> {
+        xs.reverse();
+        xs
+    }
+
+    /// Take first n elements.
+    pub fn take<T>(xs: Vec<T>, n: usize) -> Vec<T> {
+        xs.into_iter().take(n).collect()
+    }
+
+    /// Drop first n elements.
+    pub fn drop<T>(xs: Vec<T>, n: usize) -> Vec<T> {
+        xs.into_iter().skip(n).collect()
+    }
+
+    /// Find first element matching predicate.
+    pub fn find<T, F>(xs: Vec<T>, predicate: F) -> Option<T>
+    where
+        F: Fn(&T) -> bool,
+    {
+        xs.into_iter().find(predicate)
+    }
+
+    /// Check if any element matches.
+    pub fn any<T, F>(xs: &[T], predicate: F) -> bool
+    where
+        F: Fn(&T) -> bool,
+    {
+        xs.iter().any(predicate)
+    }
+
+    /// Check if all elements match.
+    pub fn all<T, F>(xs: &[T], predicate: F) -> bool
+    where
+        F: Fn(&T) -> bool,
+    {
+        xs.iter().all(predicate)
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// MATH MODULE
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "math")]
+pub mod math {
+    /// Absolute value.
+    #[inline]
+    pub fn abs(x: i64) -> i64 {
+        if x < 0 {
+            -x
+        } else {
+            x
+        }
+    }
+
+    /// Absolute value for floats.
+    #[inline]
+    pub fn abs_f(x: f64) -> f64 {
+        if x < 0.0 {
+            -x
+        } else {
+            x
+        }
+    }
+
+    /// Minimum of two values.
+    #[inline]
+    pub fn min(a: i64, b: i64) -> i64 {
+        if a < b {
+            a
+        } else {
+            b
+        }
+    }
+
+    /// Maximum of two values.
+    #[inline]
+    pub fn max(a: i64, b: i64) -> i64 {
+        if a > b {
+            a
+        } else {
+            b
+        }
+    }
+
+    /// Clamp value to range.
+    #[inline]
+    pub fn clamp(x: i64, lo: i64, hi: i64) -> i64 {
+        if x < lo {
+            lo
+        } else if x > hi {
+            hi
+        } else {
+            x
+        }
+    }
+
+    /// Integer square root (floor).
+    pub fn isqrt(n: u64) -> u64 {
+        if n == 0 {
+            return 0;
+        }
+        let mut x = n;
+        let mut y = (x + 1) / 2;
+        while y < x {
+            x = y;
+            y = (x + n / x) / 2;
+        }
+        x
+    }
+
+    /// Integer power.
+    pub fn pow(base: i64, exp: u32) -> i64 {
+        let mut result = 1i64;
+        let mut b = base;
+        let mut e = exp;
+        while e > 0 {
+            if e & 1 == 1 {
+                result = result.wrapping_mul(b);
+            }
+            b = b.wrapping_mul(b);
+            e >>= 1;
+        }
+        result
+    }
+
+    /// Greatest common divisor.
+    pub fn gcd(mut a: u64, mut b: u64) -> u64 {
+        while b != 0 {
+            let t = b;
+            b = a % b;
+            a = t;
+        }
+        a
+    }
+
+    /// Least common multiple.
+    pub fn lcm(a: u64, b: u64) -> u64 {
+        if a == 0 || b == 0 {
+            0
+        } else {
+            a / gcd(a, b) * b
+        }
+    }
+
+    /// Check if number is prime (simple trial division).
+    pub fn is_prime(n: u64) -> bool {
+        if n < 2 {
+            return false;
+        }
+        if n == 2 {
+            return true;
+        }
+        if n % 2 == 0 {
+            return false;
+        }
+        let sqrt = isqrt(n);
+        let mut i = 3;
+        while i <= sqrt {
+            if n % i == 0 {
+                return false;
+            }
+            i += 2;
+        }
+        true
+    }
+
+    // Floating-point functions (software implementations for no_std)
+
+    /// Approximate square root using Newton-Raphson.
+    pub fn sqrt(x: f64) -> f64 {
+        if x < 0.0 {
+            return f64::NAN;
+        }
+        if x == 0.0 {
+            return 0.0;
+        }
+        let mut guess = x / 2.0;
+        for _ in 0..20 {
+            guess = (guess + x / guess) / 2.0;
+        }
+        guess
+    }
+
+    /// Approximate natural logarithm.
+    pub fn ln(x: f64) -> f64 {
+        if x <= 0.0 {
+            return f64::NAN;
+        }
+        // Simple series expansion for ln(1+y) where y = (x-1)/(x+1)
+        let y = (x - 1.0) / (x + 1.0);
+        let y2 = y * y;
+        let mut sum = y;
+        let mut term = y;
+        for n in 1..50 {
+            term *= y2;
+            sum += term / (2 * n + 1) as f64;
+        }
+        2.0 * sum
+    }
+
+    /// Power function using exp(y * ln(x)).
+    pub fn powf(x: f64, y: f64) -> f64 {
+        if x == 0.0 {
+            return 0.0;
+        }
+        exp(y * ln(x))
+    }
+
+    /// Approximate exponential function.
+    pub fn exp(x: f64) -> f64 {
+        let mut sum = 1.0;
+        let mut term = 1.0;
+        for n in 1..30 {
+            term *= x / n as f64;
+            sum += term;
+        }
+        sum
+    }
+
+    // Trigonometric functions (Taylor series)
+
+    /// Approximate sine.
+    pub fn sin(x: f64) -> f64 {
+        // Reduce to [-π, π]
+        let pi = 3.141592653589793;
+        let mut x = x % (2.0 * pi);
+        if x > pi {
+            x -= 2.0 * pi;
+        }
+        if x < -pi {
+            x += 2.0 * pi;
+        }
+        // Taylor series
+        let x2 = x * x;
+        let mut term = x;
+        let mut sum = x;
+        for n in 1..15 {
+            term *= -x2 / ((2 * n) * (2 * n + 1)) as f64;
+            sum += term;
+        }
+        sum
+    }
+
+    /// Approximate cosine.
+    pub fn cos(x: f64) -> f64 {
+        let pi = 3.141592653589793;
+        sin(x + pi / 2.0)
+    }
+
+    /// Approximate tangent.
+    pub fn tan(x: f64) -> f64 {
+        sin(x) / cos(x)
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// RANDOM MODULE
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "random")]
+pub mod random {
+    use alloc::vec::Vec;
+
+    /// Simple xorshift64 PRNG state.
+    static mut SEED: u64 = 0x123456789ABCDEF0;
+
+    /// Seed the PRNG.
+    pub fn seed(s: u64) {
+        unsafe {
+            SEED = if s == 0 { 1 } else { s };
+        }
+    }
+
+    /// Generate next random u64.
+    pub fn next_u64() -> u64 {
+        unsafe {
+            let mut x = SEED;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            SEED = x;
+            x
+        }
+    }
+
+    /// Random integer in [min, max] inclusive.
+    pub fn int_range(min: i64, max: i64) -> i64 {
+        if min >= max {
+            return min;
+        }
+        let range = (max - min + 1) as u64;
+        min + (next_u64() % range) as i64
+    }
+
+    /// Random float in [0, 1).
+    pub fn float() -> f64 {
+        (next_u64() as f64) / (u64::MAX as f64)
+    }
+
+    /// Generate n random bytes.
+    pub fn bytes(n: usize) -> Vec<u8> {
+        let mut result = Vec::with_capacity(n);
+        let mut remaining = n;
+        while remaining > 0 {
+            let r = next_u64();
+            let take = remaining.min(8);
+            for i in 0..take {
+                result.push((r >> (i * 8)) as u8);
+            }
+            remaining -= take;
+        }
+        result
+    }
+
+    /// Shuffle a vector in place (Fisher-Yates).
+    pub fn shuffle<T>(xs: &mut [T]) {
+        let len = xs.len();
+        if len < 2 {
+            return;
+        }
+        for i in (1..len).rev() {
+            let j = (next_u64() as usize) % (i + 1);
+            xs.swap(i, j);
+        }
+    }
+
+    /// Pick a random element from a slice.
+    pub fn choice<T>(xs: &[T]) -> Option<&T> {
+        if xs.is_empty() {
+            None
+        } else {
+            let idx = (next_u64() as usize) % xs.len();
+            Some(&xs[idx])
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// TIME MODULE (stubs for size measurement)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "time")]
+pub mod time {
+    use alloc::string::String;
+
+    /// Opaque instant type.
+    #[derive(Clone, Copy)]
+    pub struct Instant(u64);
+
+    /// Get current time (stub - returns 0).
+    pub fn now() -> Instant {
+        // In real implementation, this would call WASI clock_time_get
+        Instant(0)
+    }
+
+    /// Get epoch seconds from instant.
+    pub fn epoch_seconds(t: Instant) -> i64 {
+        (t.0 / 1_000_000_000) as i64
+    }
+
+    /// Sleep for duration (stub - no-op).
+    pub fn sleep(_secs: u64, _nanos: u32) {
+        // In real implementation, this would call WASI poll_oneoff
+    }
+
+    /// Format instant as ISO 8601 (stub).
+    pub fn format_iso8601(t: Instant) -> String {
+        let secs = epoch_seconds(t);
+        // Simplified: just return epoch seconds as string
+        let mut s = String::new();
+        let mut n = if secs < 0 { -secs } else { secs } as u64;
+        if n == 0 {
+            return String::from("0");
+        }
+        while n > 0 {
+            s.insert(0, ((n % 10) as u8 + b'0') as char);
+            n /= 10;
+        }
+        if secs < 0 {
+            s.insert(0, '-');
+        }
+        s
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// IO MODULE (stubs for size measurement)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "io")]
+pub mod io {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    /// Read file contents (stub).
+    pub fn read_file(_path: &str) -> Result<Vec<u8>, &'static str> {
+        Err("not implemented in WASM")
+    }
+
+    /// Write file contents (stub).
+    pub fn write_file(_path: &str, _contents: &[u8]) -> Result<(), &'static str> {
+        Err("not implemented in WASM")
+    }
+
+    /// Append to file (stub).
+    pub fn append_file(_path: &str, _contents: &[u8]) -> Result<(), &'static str> {
+        Err("not implemented in WASM")
+    }
+
+    /// Check if path exists (stub).
+    pub fn exists(_path: &str) -> bool {
+        false
+    }
+
+    /// Check if path is a file (stub).
+    pub fn is_file(_path: &str) -> bool {
+        false
+    }
+
+    /// Check if path is a directory (stub).
+    pub fn is_dir(_path: &str) -> bool {
+        false
+    }
+
+    /// Create directory and parents (stub).
+    pub fn create_dir_all(_path: &str) -> Result<(), &'static str> {
+        Err("not implemented in WASM")
+    }
+
+    /// Remove file or directory (stub).
+    pub fn remove(_path: &str) -> Result<(), &'static str> {
+        Err("not implemented in WASM")
+    }
+
+    /// Get environment variable (stub).
+    pub fn env_var(_name: &str) -> Option<String> {
+        None
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// JSON MODULE (stubs for size measurement)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "json")]
+pub mod json {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    /// Simple JSON value type.
+    #[derive(Clone, Debug)]
+    pub enum Value {
+        Null,
+        Bool(bool),
+        Number(f64),
+        String(String),
+        Array(Vec<Value>),
+        // Object would need a map type
+    }
+
+    /// Parse JSON string (simplified - only handles primitives).
+    pub fn parse(s: &str) -> Option<Value> {
+        let s = s.trim();
+        if s == "null" {
+            Some(Value::Null)
+        } else if s == "true" {
+            Some(Value::Bool(true))
+        } else if s == "false" {
+            Some(Value::Bool(false))
+        } else if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+            Some(Value::String(String::from(&s[1..s.len() - 1])))
+        } else if let Ok(n) = s.parse::<f64>() {
+            Some(Value::Number(n))
+        } else {
+            None
+        }
+    }
+
+    /// Stringify JSON value.
+    pub fn stringify(v: &Value) -> String {
+        match v {
+            Value::Null => String::from("null"),
+            Value::Bool(true) => String::from("true"),
+            Value::Bool(false) => String::from("false"),
+            Value::Number(n) => {
+                // Simple float to string
+                let mut s = String::new();
+                let n = *n;
+                if n < 0.0 {
+                    s.push('-');
+                }
+                let n = if n < 0.0 { -n } else { n };
+                let int_part = n as u64;
+                // Just output integer part for simplicity
+                let mut digits = Vec::new();
+                let mut i = int_part;
+                if i == 0 {
+                    digits.push(b'0');
+                }
+                while i > 0 {
+                    digits.push((i % 10) as u8 + b'0');
+                    i /= 10;
+                }
+                for d in digits.into_iter().rev() {
+                    s.push(d as char);
+                }
+                s
+            }
+            Value::String(s) => {
+                let mut out = String::with_capacity(s.len() + 2);
+                out.push('"');
+                out.push_str(s);
+                out.push('"');
+                out
+            }
+            Value::Array(arr) => {
+                let mut out = String::from("[");
+                for (i, v) in arr.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    out.push_str(&stringify(v));
+                }
+                out.push(']');
+                out
+            }
+        }
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// PANIC HANDLER (required for no_std)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// Global allocator for no_std
+#[cfg(not(test))]
+mod alloc_impl {
+    use core::alloc::{GlobalAlloc, Layout};
+
+    struct BumpAllocator;
+
+    static mut HEAP: [u8; 65536] = [0; 65536];
+    static mut HEAP_PTR: usize = 0;
+
+    unsafe impl GlobalAlloc for BumpAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let align = layout.align();
+            let size = layout.size();
+            let ptr = HEAP_PTR;
+            let aligned = (ptr + align - 1) & !(align - 1);
+            let new_ptr = aligned + size;
+            if new_ptr > HEAP.len() {
+                core::ptr::null_mut()
+            } else {
+                HEAP_PTR = new_ptr;
+                HEAP.as_mut_ptr().add(aligned)
+            }
+        }
+
+        unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
+            // Bump allocator doesn't deallocate
+        }
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: BumpAllocator = BumpAllocator;
+}

--- a/experiments/013_unicode_strategies/README.md
+++ b/experiments/013_unicode_strategies/README.md
@@ -1,0 +1,201 @@
+# Experiment 013 — Unicode Strategies
+
+A 2×2 matrix comparing Unicode handling approaches in WASM:
+
+|                   | **Server-side tables** | **Host delegation (JS)** |
+|-------------------|------------------------|--------------------------|
+| **With Unicode**  | Leg 1: embedded tables | Leg 2: import from host  |
+| **ASCII-only**    | Leg 3: ASCII fallback  | Leg 4: ASCII (no imports)|
+
+## Motivation
+
+Unicode support in WASM is expensive. A full Unicode case-mapping table (for
+`to_upper`/`to_lower`) adds 50-150KB to a `.wasm` binary. This experiment
+measures the trade-offs between:
+
+1. **Embedded tables** — self-contained, portable, large
+2. **Host delegation** — smaller WASM, requires JS glue, browser-only
+3. **ASCII fallback** — tiny, limited functionality
+
+## Structure
+
+```
+013_unicode_strategies/
+├── unicode-lib/            # Shared Rust string library
+│   ├── Cargo.toml
+│   └── src/lib.rs
+├── legs/
+│   ├── leg1_embedded/      # Full Unicode tables in WASM
+│   ├── leg2_host_js/       # Delegate to JS TextEncoder/Intl
+│   ├── leg3_ascii_only/    # ASCII-only fallback
+│   └── leg4_ascii_no_import/ # ASCII, no host imports
+├── host/                   # JS host for leg2
+│   ├── unicode_bridge.js
+│   └── test.html
+├── build.sh
+├── benchmark.sh
+└── README.md
+```
+
+## Hypotheses
+
+| # | Hypothesis | Status |
+|---|-----------|--------|
+| H1 | **Embedded Unicode** adds 50-150KB to .wasm size | — |
+| H2 | **Host delegation** keeps WASM under 20KB for string ops | — |
+| H3 | **ASCII fallback** is smallest (<5KB for string module) | — |
+| H4 | **Runtime perf** is comparable — host calls add <1μs/op | — |
+| H5 | **Host delegation** works in browser, fails in WASI CLI | — |
+
+## Implementation Details
+
+### Leg 1: Embedded Unicode Tables
+
+Uses the `unicode-case` or `unicode-normalization` crate. All case mappings,
+character properties, and normalization tables compiled into the WASM binary.
+
+```rust
+// In WASM — uses embedded tables
+pub fn to_upper(s: &str) -> String {
+    s.chars().map(|c| c.to_uppercase()).flatten().collect()
+}
+```
+
+### Leg 2: Host Delegation (JS)
+
+WASM imports host functions for Unicode operations. The JS host uses native
+`String.prototype.toUpperCase()` and `Intl.Segmenter`.
+
+```rust
+// In WASM — imports from host
+extern "C" {
+    fn _host_to_upper(ptr: *const u8, len: usize, out: *mut u8) -> usize;
+}
+
+pub fn to_upper(s: &str) -> String {
+    let mut buf = vec![0u8; s.len() * 4]; // UTF-8 can expand
+    let len = unsafe { _host_to_upper(s.as_ptr(), s.len(), buf.as_mut_ptr()) };
+    buf.truncate(len);
+    String::from_utf8(buf).unwrap()
+}
+```
+
+```javascript
+// In host (JS)
+const imports = {
+    env: {
+        _host_to_upper(ptr, len, outPtr) {
+            const str = readString(ptr, len);
+            const upper = str.toUpperCase();
+            return writeString(outPtr, upper);
+        }
+    }
+};
+```
+
+### Leg 3: ASCII-Only
+
+No Unicode tables. Operations only work on ASCII range (0x00-0x7F). Non-ASCII
+bytes pass through unchanged.
+
+```rust
+pub fn to_upper(s: &str) -> String {
+    s.bytes().map(|b| {
+        if b >= b'a' && b <= b'z' { b - 32 } else { b }
+    }).map(|b| b as char).collect()
+}
+```
+
+### Leg 4: ASCII, No Imports
+
+Same as Leg 3 but compiled without any host imports. Tests the baseline size
+of a pure-compute WASM module.
+
+## Test Cases
+
+Each leg runs the same test suite:
+
+```rust
+assert_eq!(to_upper("hello"), "HELLO");           // ASCII
+assert_eq!(to_upper("café"), "CAFÉ");             // Latin-1 Extended
+assert_eq!(to_upper("naïve"), "NAÏVE");           // Diacritics
+assert_eq!(to_upper("Größe"), "GRÖSSE");          // German sharp s → SS
+assert_eq!(to_upper("σ"), "Σ");                   // Greek
+assert_eq!(to_upper("и"), "И");                   // Cyrillic
+
+// Character iteration
+assert_eq!(char_count("hello"), 5);
+assert_eq!(char_count("héllo"), 5);               // 6 bytes, 5 chars
+assert_eq!(char_count("日本語"), 3);               // 9 bytes, 3 chars
+assert_eq!(char_count("👨‍👩‍👧"), 1);                  // 18 bytes, 1 grapheme
+
+// Whitespace detection
+assert!(is_whitespace(' '));
+assert!(is_whitespace('\u{00A0}'));               // Non-breaking space
+assert!(is_whitespace('\u{3000}'));               // Ideographic space
+```
+
+Leg 3/4 will fail non-ASCII cases — that's expected and part of the comparison.
+
+## Results
+
+*Run `./benchmark.sh` to populate.*
+
+### Size Comparison
+
+| Leg | Strategy | .wasm size | gzip size | Unicode support |
+|-----|----------|-----------|-----------|-----------------|
+| 1 | Embedded tables | | | Full |
+| 2 | Host delegation | | | Full (browser) |
+| 3 | ASCII fallback | | | ASCII only |
+| 4 | ASCII, no imports | | | ASCII only |
+
+### Correctness Matrix
+
+| Test case | Leg 1 | Leg 2 | Leg 3 | Leg 4 |
+|-----------|-------|-------|-------|-------|
+| ASCII to_upper | ✓ | ✓ | ✓ | ✓ |
+| Latin-1 to_upper | ✓ | ✓ | ✗ | ✗ |
+| German ß → SS | ✓ | ✓ | ✗ | ✗ |
+| Greek/Cyrillic | ✓ | ✓ | ✗ | ✗ |
+| Grapheme count | ✓ | ✓ | ✗ | ✗ |
+
+### Performance (μs/op)
+
+| Operation | Leg 1 | Leg 2 | Leg 3 | Leg 4 |
+|-----------|-------|-------|-------|-------|
+| to_upper (10 chars) | | | | |
+| char_count (100 chars) | | | | |
+| is_whitespace (1 char) | | | | |
+
+## Running
+
+```bash
+# Build all legs
+./build.sh
+
+# Run size + correctness benchmark
+./benchmark.sh
+
+# Test leg 2 in browser
+cd host && python3 -m http.server 8080
+# Open http://localhost:8080/test.html
+```
+
+## Prerequisites
+
+```bash
+rustup target add wasm32-wasip1
+rustup target add wasm32-unknown-unknown  # for browser leg
+cargo install wasm-opt
+```
+
+## Conclusions
+
+*To be filled after running benchmarks.*
+
+The recommended strategy depends on:
+- **Portability requirement**: If WASI CLI support is needed, Leg 1 or Leg 3
+- **Size budget**: If <20KB is required, Leg 2 or Leg 3/4
+- **Unicode requirement**: If full i18n is needed, Leg 1 or Leg 2
+- **Browser-only**: Leg 2 is optimal (small + full Unicode via host)

--- a/experiments/013_unicode_strategies/benchmark.sh
+++ b/experiments/013_unicode_strategies/benchmark.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Benchmark Unicode strategies.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ ! -d "legs" ] || [ -z "$(ls -A legs/*/output.wasm 2>/dev/null)" ]; then
+    echo "No WASM files found. Run ./build.sh first."
+    exit 1
+fi
+
+echo "=== Experiment 013: Unicode Strategies Benchmark ==="
+echo ""
+
+# ─── Size Comparison ───────────────────────────────────────────────────────────
+
+echo "Size Comparison"
+echo "───────────────"
+printf "%-30s %10s %10s %10s\n" "Leg" ".wasm" "gzip" "brotli"
+printf "%-30s %10s %10s %10s\n" "---" "-----" "----" "------"
+
+for leg in legs/*/output.wasm; do
+    name=$(dirname "$leg" | xargs basename)
+    size=$(wc -c < "$leg" | tr -d ' ')
+    gzip_size=$(gzip -c "$leg" | wc -c | tr -d ' ')
+
+    if command -v brotli &>/dev/null; then
+        brotli_size=$(brotli -c "$leg" | wc -c | tr -d ' ')
+    else
+        brotli_size="-"
+    fi
+
+    printf "%-30s %10s %10s %10s\n" "$name" "$size" "$gzip_size" "$brotli_size"
+done
+
+echo ""
+
+# ─── Feature Analysis ──────────────────────────────────────────────────────────
+
+echo "Feature Analysis"
+echo "────────────────"
+
+# Embedded vs ASCII difference
+if [ -f "legs/leg1_embedded/output.wasm" ] && [ -f "legs/leg3_ascii_only/output.wasm" ]; then
+    embedded=$(wc -c < "legs/leg1_embedded/output.wasm" | tr -d ' ')
+    ascii=$(wc -c < "legs/leg3_ascii_only/output.wasm" | tr -d ' ')
+    diff=$((embedded - ascii))
+    echo "Unicode tables add: ${diff} bytes ($(echo "scale=1; $diff / 1024" | bc) KB)"
+fi
+
+# Host delegation size
+if [ -f "legs/leg2_host_js/output.wasm" ]; then
+    host=$(wc -c < "legs/leg2_host_js/output.wasm" | tr -d ' ')
+    echo "Host delegation module: ${host} bytes"
+fi
+
+echo ""
+
+# ─── WASM Function Analysis ────────────────────────────────────────────────────
+
+if command -v wasm-objdump &>/dev/null; then
+    echo "Exports per leg"
+    echo "───────────────"
+
+    for leg in legs/*/output.wasm; do
+        name=$(dirname "$leg" | xargs basename)
+        exports=$(wasm-objdump -x "$leg" 2>/dev/null | grep -c "^ - func" || echo "0")
+        imports=$(wasm-objdump -x "$leg" 2>/dev/null | grep -c "^ - func\[" || echo "0")
+        echo "$name: $exports exports"
+    done
+
+    echo ""
+fi
+
+# ─── Correctness Matrix ────────────────────────────────────────────────────────
+
+echo "Expected Correctness Matrix"
+echo "───────────────────────────"
+echo ""
+echo "| Test case          | Embedded | Host JS | ASCII |"
+echo "|--------------------|----------|---------|-------|"
+echo "| ASCII to_upper     |    ✓     |    ✓    |   ✓   |"
+echo "| Latin-1 to_upper   |    ✓     |    ✓    |   ✗   |"
+echo "| Greek to_upper     |    ✓     |    ✓    |   ✗   |"
+echo "| Cyrillic to_upper  |    ✓     |    ✓    |   ✗   |"
+echo "| Unicode whitespace |    ✓     |    ✓    |   ✗   |"
+echo "| Grapheme counting  |    ✗     |    ✓    |   ✗   |"
+echo ""
+echo "(Host JS requires browser with Intl.Segmenter for grapheme counting)"
+echo ""
+echo "To run browser tests: cd host && python3 -m http.server 8080"
+echo "Then open http://localhost:8080/test.html"

--- a/experiments/013_unicode_strategies/build.sh
+++ b/experiments/013_unicode_strategies/build.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Build all legs of the Unicode strategies experiment.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "=== Building Experiment 013: Unicode Strategies ==="
+
+# Ensure targets are available
+rustup target add wasm32-unknown-unknown 2>/dev/null || true
+
+# Check for wasm-opt
+if ! command -v wasm-opt &>/dev/null; then
+    echo "Warning: wasm-opt not found. Binaries will not be optimized."
+    HAS_WASM_OPT=0
+else
+    HAS_WASM_OPT=1
+fi
+
+# ─── Leg 1: Embedded Unicode Tables ────────────────────────────────────────────
+
+echo ""
+echo "Leg 1: Embedded Unicode tables..."
+
+mkdir -p legs/leg1_embedded
+
+# Build with embedded feature
+cargo build --manifest-path unicode-lib/Cargo.toml \
+    --target wasm32-unknown-unknown \
+    --release \
+    --no-default-features \
+    --features embedded
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/unicode_lib.wasm \
+        -o legs/leg1_embedded/output.wasm
+else
+    cp target/wasm32-unknown-unknown/release/unicode_lib.wasm \
+        legs/leg1_embedded/output.wasm
+fi
+
+echo "  → legs/leg1_embedded/output.wasm"
+
+# ─── Leg 2: Host Delegation (JS) ───────────────────────────────────────────────
+
+echo ""
+echo "Leg 2: Host delegation (JS)..."
+
+mkdir -p legs/leg2_host_js
+
+# Build with host feature
+cargo build --manifest-path unicode-lib/Cargo.toml \
+    --target wasm32-unknown-unknown \
+    --release \
+    --no-default-features \
+    --features host
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/unicode_lib.wasm \
+        -o legs/leg2_host_js/output.wasm
+else
+    cp target/wasm32-unknown-unknown/release/unicode_lib.wasm \
+        legs/leg2_host_js/output.wasm
+fi
+
+echo "  → legs/leg2_host_js/output.wasm"
+
+# ─── Leg 3: ASCII Only ─────────────────────────────────────────────────────────
+
+echo ""
+echo "Leg 3: ASCII only..."
+
+mkdir -p legs/leg3_ascii_only
+
+# Build with ascii feature
+cargo build --manifest-path unicode-lib/Cargo.toml \
+    --target wasm32-unknown-unknown \
+    --release \
+    --no-default-features \
+    --features ascii
+
+if [ "$HAS_WASM_OPT" -eq 1 ]; then
+    wasm-opt -Oz target/wasm32-unknown-unknown/release/unicode_lib.wasm \
+        -o legs/leg3_ascii_only/output.wasm
+else
+    cp target/wasm32-unknown-unknown/release/unicode_lib.wasm \
+        legs/leg3_ascii_only/output.wasm
+fi
+
+echo "  → legs/leg3_ascii_only/output.wasm"
+
+# ─── Leg 4: ASCII No Import ────────────────────────────────────────────────────
+
+echo ""
+echo "Leg 4: ASCII, no imports..."
+
+mkdir -p legs/leg4_ascii_no_import
+
+# Same as Leg 3 (ascii feature doesn't have host imports anyway)
+# This is to demonstrate the baseline without any external dependencies
+cp legs/leg3_ascii_only/output.wasm legs/leg4_ascii_no_import/output.wasm
+
+echo "  → legs/leg4_ascii_no_import/output.wasm"
+
+# ─── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Build Complete ==="
+echo ""
+echo "Output files:"
+
+for leg in legs/leg*/output.wasm; do
+    size=$(wc -c < "$leg" | tr -d ' ')
+    echo "  $leg: ${size} bytes"
+done
+
+echo ""
+echo "Run ./benchmark.sh for full analysis."
+echo "To test in browser: cd host && python3 -m http.server 8080"

--- a/experiments/013_unicode_strategies/host/test.html
+++ b/experiments/013_unicode_strategies/host/test.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Unicode Strategies Test</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --fg: #eaeaea;
+      --accent: #00d4ff;
+      --success: #00ff88;
+      --error: #ff4444;
+      --muted: #666;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      background: var(--bg);
+      color: var(--fg);
+      padding: 2rem;
+      line-height: 1.6;
+    }
+
+    h1 {
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+
+    .test-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+
+    .leg {
+      background: rgba(255,255,255,0.05);
+      border-radius: 8px;
+      padding: 1rem;
+    }
+
+    .leg h2 {
+      font-size: 0.9rem;
+      color: var(--accent);
+      margin-bottom: 0.5rem;
+    }
+
+    .leg .size {
+      font-size: 0.8rem;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+    }
+
+    .test-case {
+      display: flex;
+      justify-content: space-between;
+      padding: 0.25rem 0;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+    }
+
+    .test-case:last-child {
+      border-bottom: none;
+    }
+
+    .test-case .name {
+      color: var(--muted);
+    }
+
+    .test-case .result {
+      font-weight: bold;
+    }
+
+    .test-case .result.pass {
+      color: var(--success);
+    }
+
+    .test-case .result.fail {
+      color: var(--error);
+    }
+
+    .summary {
+      margin-top: 2rem;
+      padding: 1rem;
+      background: rgba(255,255,255,0.05);
+      border-radius: 8px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 0.5rem;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 0.5rem;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+    }
+
+    th {
+      color: var(--accent);
+    }
+
+    .loading {
+      color: var(--muted);
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <h1>Experiment 013: Unicode Strategies</h1>
+  <p>Comparing embedded tables vs host delegation vs ASCII-only.</p>
+
+  <div class="test-grid" id="results">
+    <p class="loading">Loading WASM modules...</p>
+  </div>
+
+  <div class="summary" id="summary" style="display: none;">
+    <h2>Size Comparison</h2>
+    <table id="size-table">
+      <thead>
+        <tr>
+          <th>Leg</th>
+          <th>Strategy</th>
+          <th>.wasm size</th>
+          <th>Tests passed</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <script type="module">
+    import { createUnicodeLib, createImports } from './unicode_bridge.js';
+
+    const TEST_CASES = [
+      { name: 'ASCII upper', fn: lib => lib.toUpper('hello'), expected: 'HELLO' },
+      { name: 'ASCII lower', fn: lib => lib.toLower('HELLO'), expected: 'hello' },
+      { name: 'Latin-1 upper', fn: lib => lib.toUpper('café'), expected: 'CAFÉ' },
+      { name: 'Greek upper', fn: lib => lib.toUpper('αβγ'), expected: 'ΑΒΓ' },
+      { name: 'Cyrillic upper', fn: lib => lib.toUpper('абв'), expected: 'АБВ' },
+      { name: 'Whitespace space', fn: lib => lib.isWhitespace(' '), expected: true },
+      { name: 'Whitespace NBSP', fn: lib => lib.isWhitespace(' '), expected: true },
+      { name: 'Char count ASCII', fn: lib => lib.charCount('hello'), expected: 5 },
+      { name: 'Char count UTF-8', fn: lib => lib.charCount('héllo'), expected: 5 },
+      { name: 'Char count CJK', fn: lib => lib.charCount('日本語'), expected: 3 },
+    ];
+
+    const LEGS = [
+      { id: 'leg1', name: 'Leg 1: Embedded Tables', wasm: '../legs/leg1_embedded/output.wasm' },
+      { id: 'leg2', name: 'Leg 2: Host Delegation', wasm: '../legs/leg2_host_js/output.wasm' },
+      { id: 'leg3', name: 'Leg 3: ASCII Only', wasm: '../legs/leg3_ascii_only/output.wasm' },
+      { id: 'leg4', name: 'Leg 4: ASCII No Import', wasm: '../legs/leg4_ascii_no_import/output.wasm' },
+    ];
+
+    async function runTests() {
+      const resultsDiv = document.getElementById('results');
+      resultsDiv.innerHTML = '';
+
+      const summaryData = [];
+
+      for (const leg of LEGS) {
+        const legDiv = document.createElement('div');
+        legDiv.className = 'leg';
+        legDiv.innerHTML = `<h2>${leg.name}</h2><div class="size">Loading...</div>`;
+        resultsDiv.appendChild(legDiv);
+
+        try {
+          const response = await fetch(leg.wasm);
+          if (!response.ok) {
+            throw new Error(`Failed to load: ${response.status}`);
+          }
+
+          const bytes = await response.arrayBuffer();
+          const size = bytes.byteLength;
+          legDiv.querySelector('.size').textContent = `Size: ${(size / 1024).toFixed(2)} KB`;
+
+          let lib;
+          if (leg.id === 'leg2') {
+            // Host delegation needs special instantiation
+            const memory = new WebAssembly.Memory({ initial: 2 });
+            const imports = createImports(memory);
+            imports.env.memory = memory;
+            const { instance } = await WebAssembly.instantiate(bytes, imports);
+            lib = new (await import('./unicode_bridge.js')).UnicodeLib(instance, memory);
+          } else {
+            // Self-contained modules
+            const { instance } = await WebAssembly.instantiate(bytes, {});
+            // Create a simple wrapper
+            const memory = instance.exports.memory || new WebAssembly.Memory({ initial: 1 });
+            lib = new (await import('./unicode_bridge.js')).UnicodeLib(instance, memory);
+          }
+
+          let passed = 0;
+          let total = 0;
+
+          for (const test of TEST_CASES) {
+            total++;
+            const testDiv = document.createElement('div');
+            testDiv.className = 'test-case';
+
+            try {
+              const result = test.fn(lib);
+              const pass = result === test.expected;
+              if (pass) passed++;
+
+              testDiv.innerHTML = `
+                <span class="name">${test.name}</span>
+                <span class="result ${pass ? 'pass' : 'fail'}">${pass ? '✓' : `✗ (${JSON.stringify(result)})`}</span>
+              `;
+            } catch (e) {
+              testDiv.innerHTML = `
+                <span class="name">${test.name}</span>
+                <span class="result fail">✗ ${e.message}</span>
+              `;
+            }
+
+            legDiv.appendChild(testDiv);
+          }
+
+          summaryData.push({ leg: leg.name, size, passed, total });
+
+        } catch (e) {
+          legDiv.innerHTML += `<p class="result fail">Error: ${e.message}</p>`;
+          summaryData.push({ leg: leg.name, size: null, passed: 0, total: TEST_CASES.length });
+        }
+      }
+
+      // Update summary table
+      const tbody = document.querySelector('#size-table tbody');
+      for (const data of summaryData) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${data.leg.split(':')[0]}</td>
+          <td>${data.leg.split(':')[1] || ''}</td>
+          <td>${data.size ? (data.size / 1024).toFixed(2) + ' KB' : '—'}</td>
+          <td>${data.passed}/${data.total}</td>
+        `;
+        tbody.appendChild(tr);
+      }
+      document.getElementById('summary').style.display = 'block';
+    }
+
+    runTests().catch(e => {
+      document.getElementById('results').innerHTML = `<p class="result fail">Error: ${e.message}</p>`;
+    });
+  </script>
+</body>
+</html>

--- a/experiments/013_unicode_strategies/host/unicode_bridge.js
+++ b/experiments/013_unicode_strategies/host/unicode_bridge.js
@@ -1,0 +1,197 @@
+/**
+ * JavaScript host bridge for WASM Unicode operations.
+ *
+ * Provides native Unicode support to WASM modules via imports.
+ * Uses browser's built-in String methods and Intl APIs.
+ */
+
+// TextEncoder/TextDecoder for UTF-8 handling
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+// Grapheme segmenter for accurate character counting (emoji, etc.)
+const segmenter = typeof Intl !== 'undefined' && Intl.Segmenter
+  ? new Intl.Segmenter('en', { granularity: 'grapheme' })
+  : null;
+
+/**
+ * Create import object for WASM module.
+ * @param {WebAssembly.Memory} memory - WASM linear memory
+ * @returns {Object} Import object for WebAssembly.instantiate
+ */
+export function createImports(memory) {
+  return {
+    env: {
+      /**
+       * Convert string to uppercase.
+       * @param {number} ptr - Pointer to UTF-8 string in WASM memory
+       * @param {number} len - Length of input string in bytes
+       * @param {number} outPtr - Pointer to output buffer
+       * @param {number} outCap - Capacity of output buffer
+       * @returns {number} Length of result in bytes
+       */
+      _host_to_upper(ptr, len, outPtr, outCap) {
+        const input = readString(memory, ptr, len);
+        const result = input.toUpperCase();
+        return writeString(memory, outPtr, outCap, result);
+      },
+
+      /**
+       * Convert string to lowercase.
+       */
+      _host_to_lower(ptr, len, outPtr, outCap) {
+        const input = readString(memory, ptr, len);
+        const result = input.toLowerCase();
+        return writeString(memory, outPtr, outCap, result);
+      },
+
+      /**
+       * Check if code point is whitespace.
+       * @param {number} cp - Unicode code point
+       * @returns {number} 1 if whitespace, 0 otherwise
+       */
+      _host_is_whitespace(cp) {
+        const char = String.fromCodePoint(cp);
+        // Use regex with Unicode property escape
+        return /^\s$/.test(char) ? 1 : 0;
+      },
+
+      /**
+       * Count grapheme clusters in string.
+       * Uses Intl.Segmenter for accurate emoji counting.
+       */
+      _host_char_count(ptr, len) {
+        const input = readString(memory, ptr, len);
+
+        if (segmenter) {
+          // Use grapheme segmenter for accurate counting
+          return [...segmenter.segment(input)].length;
+        } else {
+          // Fallback to code point counting
+          return [...input].length;
+        }
+      },
+    },
+  };
+}
+
+/**
+ * Read UTF-8 string from WASM memory.
+ */
+function readString(memory, ptr, len) {
+  const bytes = new Uint8Array(memory.buffer, ptr, len);
+  return decoder.decode(bytes);
+}
+
+/**
+ * Write UTF-8 string to WASM memory.
+ * @returns {number} Length of written bytes
+ */
+function writeString(memory, ptr, cap, str) {
+  const bytes = encoder.encode(str);
+  const len = Math.min(bytes.length, cap);
+  const dest = new Uint8Array(memory.buffer, ptr, len);
+  dest.set(bytes.subarray(0, len));
+  return len;
+}
+
+/**
+ * Load and instantiate a WASM module with Unicode bridge.
+ * @param {string|URL|ArrayBuffer} source - WASM source
+ * @returns {Promise<{instance: WebAssembly.Instance, memory: WebAssembly.Memory}>}
+ */
+export async function loadWithUnicodeBridge(source) {
+  // Create shared memory
+  const memory = new WebAssembly.Memory({ initial: 2, maximum: 10 });
+
+  // Fetch and compile
+  let bytes;
+  if (source instanceof ArrayBuffer) {
+    bytes = source;
+  } else {
+    const response = await fetch(source);
+    bytes = await response.arrayBuffer();
+  }
+
+  // Instantiate with imports
+  const imports = createImports(memory);
+  imports.env.memory = memory;
+
+  const { instance } = await WebAssembly.instantiate(bytes, imports);
+
+  return { instance, memory };
+}
+
+/**
+ * High-level wrapper for string operations.
+ */
+export class UnicodeLib {
+  constructor(instance, memory) {
+    this.instance = instance;
+    this.memory = memory;
+    this.exports = instance.exports;
+
+    // Get buffer pointer from WASM
+    this.bufferPtr = this.exports.get_buffer_ptr();
+  }
+
+  /**
+   * Write string to WASM buffer.
+   */
+  writeInput(str) {
+    const bytes = encoder.encode(str);
+    const view = new Uint8Array(this.memory.buffer, this.bufferPtr, 4096);
+    view.set(bytes);
+    return bytes.length;
+  }
+
+  /**
+   * Read string from WASM buffer.
+   */
+  readOutput(len) {
+    const bytes = new Uint8Array(this.memory.buffer, this.bufferPtr, len);
+    return decoder.decode(bytes);
+  }
+
+  /**
+   * Convert string to uppercase.
+   */
+  toUpper(str) {
+    const inputLen = this.writeInput(str);
+    const outputLen = this.exports.wasm_to_upper(inputLen);
+    return this.readOutput(outputLen);
+  }
+
+  /**
+   * Convert string to lowercase.
+   */
+  toLower(str) {
+    const inputLen = this.writeInput(str);
+    const outputLen = this.exports.wasm_to_lower(inputLen);
+    return this.readOutput(outputLen);
+  }
+
+  /**
+   * Check if character is whitespace.
+   */
+  isWhitespace(char) {
+    const cp = char.codePointAt(0);
+    return this.exports.wasm_is_whitespace(cp) !== 0;
+  }
+
+  /**
+   * Count characters in string.
+   */
+  charCount(str) {
+    const inputLen = this.writeInput(str);
+    return this.exports.wasm_char_count(inputLen);
+  }
+}
+
+/**
+ * Create UnicodeLib from WASM source.
+ */
+export async function createUnicodeLib(source) {
+  const { instance, memory } = await loadWithUnicodeBridge(source);
+  return new UnicodeLib(instance, memory);
+}

--- a/experiments/013_unicode_strategies/unicode-lib/Cargo.toml
+++ b/experiments/013_unicode_strategies/unicode-lib/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "unicode-lib"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["embedded"]
+embedded = []      # Full Unicode tables in WASM
+host = []          # Delegate to JS host
+ascii = []         # ASCII-only fallback
+
+[dependencies]
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1

--- a/experiments/013_unicode_strategies/unicode-lib/src/lib.rs
+++ b/experiments/013_unicode_strategies/unicode-lib/src/lib.rs
@@ -1,0 +1,512 @@
+//! Unicode string library with multiple implementation strategies.
+//!
+//! Feature flags control which strategy is used:
+//! - `embedded`: Full Unicode tables compiled into WASM (largest, most portable)
+//! - `host`: Delegate to JS host via imports (smallest, browser-only)
+//! - `ascii`: ASCII-only fallback (tiny, limited functionality)
+
+#![no_std]
+
+extern crate alloc;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// EMBEDDED UNICODE TABLES (Leg 1)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "embedded")]
+mod embedded {
+    use alloc::string::String;
+
+    // ─── Unicode Case Mapping Tables ──────────────────────────────────────────
+    // These are simplified; real tables from unicode-case crate are larger.
+    // Format: (code_point, uppercase_code_point)
+
+    /// Simple case mappings for common scripts.
+    /// Real Unicode tables have ~1,400 entries; this is a representative subset.
+    static UPPER_MAP: &[(u32, u32)] = &[
+        // Latin lowercase a-z → A-Z
+        (0x0061, 0x0041), (0x0062, 0x0042), (0x0063, 0x0043), (0x0064, 0x0044),
+        (0x0065, 0x0045), (0x0066, 0x0046), (0x0067, 0x0047), (0x0068, 0x0048),
+        (0x0069, 0x0049), (0x006A, 0x004A), (0x006B, 0x004B), (0x006C, 0x004C),
+        (0x006D, 0x004D), (0x006E, 0x004E), (0x006F, 0x004F), (0x0070, 0x0050),
+        (0x0071, 0x0051), (0x0072, 0x0052), (0x0073, 0x0053), (0x0074, 0x0054),
+        (0x0075, 0x0055), (0x0076, 0x0056), (0x0077, 0x0057), (0x0078, 0x0058),
+        (0x0079, 0x0059), (0x007A, 0x005A),
+        // Latin Extended-A
+        (0x00E0, 0x00C0), // à → À
+        (0x00E1, 0x00C1), // á → Á
+        (0x00E2, 0x00C2), // â → Â
+        (0x00E3, 0x00C3), // ã → Ã
+        (0x00E4, 0x00C4), // ä → Ä
+        (0x00E5, 0x00C5), // å → Å
+        (0x00E6, 0x00C6), // æ → Æ
+        (0x00E7, 0x00C7), // ç → Ç
+        (0x00E8, 0x00C8), // è → È
+        (0x00E9, 0x00C9), // é → É
+        (0x00EA, 0x00CA), // ê → Ê
+        (0x00EB, 0x00CB), // ë → Ë
+        (0x00EC, 0x00CC), // ì → Ì
+        (0x00ED, 0x00CD), // í → Í
+        (0x00EE, 0x00CE), // î → Î
+        (0x00EF, 0x00CF), // ï → Ï
+        (0x00F0, 0x00D0), // ð → Ð
+        (0x00F1, 0x00D1), // ñ → Ñ
+        (0x00F2, 0x00D2), // ò → Ò
+        (0x00F3, 0x00D3), // ó → Ó
+        (0x00F4, 0x00D4), // ô → Ô
+        (0x00F5, 0x00D5), // õ → Õ
+        (0x00F6, 0x00D6), // ö → Ö
+        (0x00F8, 0x00D8), // ø → Ø
+        (0x00F9, 0x00D9), // ù → Ù
+        (0x00FA, 0x00DA), // ú → Ú
+        (0x00FB, 0x00DB), // û → Û
+        (0x00FC, 0x00DC), // ü → Ü
+        (0x00FD, 0x00DD), // ý → Ý
+        (0x00FE, 0x00DE), // þ → Þ
+        (0x00FF, 0x0178), // ÿ → Ÿ
+        // Greek lowercase α-ω → Α-Ω
+        (0x03B1, 0x0391), // α → Α
+        (0x03B2, 0x0392), // β → Β
+        (0x03B3, 0x0393), // γ → Γ
+        (0x03B4, 0x0394), // δ → Δ
+        (0x03B5, 0x0395), // ε → Ε
+        (0x03B6, 0x0396), // ζ → Ζ
+        (0x03B7, 0x0397), // η → Η
+        (0x03B8, 0x0398), // θ → Θ
+        (0x03B9, 0x0399), // ι → Ι
+        (0x03BA, 0x039A), // κ → Κ
+        (0x03BB, 0x039B), // λ → Λ
+        (0x03BC, 0x039C), // μ → Μ
+        (0x03BD, 0x039D), // ν → Ν
+        (0x03BE, 0x039E), // ξ → Ξ
+        (0x03BF, 0x039F), // ο → Ο
+        (0x03C0, 0x03A0), // π → Π
+        (0x03C1, 0x03A1), // ρ → Ρ
+        (0x03C3, 0x03A3), // σ → Σ
+        (0x03C4, 0x03A4), // τ → Τ
+        (0x03C5, 0x03A5), // υ → Υ
+        (0x03C6, 0x03A6), // φ → Φ
+        (0x03C7, 0x03A7), // χ → Χ
+        (0x03C8, 0x03A8), // ψ → Ψ
+        (0x03C9, 0x03A9), // ω → Ω
+        // Cyrillic lowercase а-я → А-Я
+        (0x0430, 0x0410), (0x0431, 0x0411), (0x0432, 0x0412), (0x0433, 0x0413),
+        (0x0434, 0x0414), (0x0435, 0x0415), (0x0436, 0x0416), (0x0437, 0x0417),
+        (0x0438, 0x0418), (0x0439, 0x0419), (0x043A, 0x041A), (0x043B, 0x041B),
+        (0x043C, 0x041C), (0x043D, 0x041D), (0x043E, 0x041E), (0x043F, 0x041F),
+        (0x0440, 0x0420), (0x0441, 0x0421), (0x0442, 0x0422), (0x0443, 0x0423),
+        (0x0444, 0x0424), (0x0445, 0x0425), (0x0446, 0x0426), (0x0447, 0x0427),
+        (0x0448, 0x0428), (0x0449, 0x0429), (0x044A, 0x042A), (0x044B, 0x042B),
+        (0x044C, 0x042C), (0x044D, 0x042D), (0x044E, 0x042E), (0x044F, 0x042F),
+    ];
+
+    /// Unicode whitespace characters.
+    static WHITESPACE: &[u32] = &[
+        0x0009, // Tab
+        0x000A, // Line Feed
+        0x000B, // Vertical Tab
+        0x000C, // Form Feed
+        0x000D, // Carriage Return
+        0x0020, // Space
+        0x0085, // Next Line
+        0x00A0, // Non-breaking Space
+        0x1680, // Ogham Space Mark
+        0x2000, // En Quad
+        0x2001, // Em Quad
+        0x2002, // En Space
+        0x2003, // Em Space
+        0x2004, // Three-Per-Em Space
+        0x2005, // Four-Per-Em Space
+        0x2006, // Six-Per-Em Space
+        0x2007, // Figure Space
+        0x2008, // Punctuation Space
+        0x2009, // Thin Space
+        0x200A, // Hair Space
+        0x2028, // Line Separator
+        0x2029, // Paragraph Separator
+        0x202F, // Narrow No-Break Space
+        0x205F, // Medium Mathematical Space
+        0x3000, // Ideographic Space
+    ];
+
+    /// Look up uppercase mapping using binary search.
+    fn lookup_upper(cp: u32) -> Option<u32> {
+        // Binary search for efficiency
+        let mut lo = 0;
+        let mut hi = UPPER_MAP.len();
+        while lo < hi {
+            let mid = (lo + hi) / 2;
+            if UPPER_MAP[mid].0 < cp {
+                lo = mid + 1;
+            } else if UPPER_MAP[mid].0 > cp {
+                hi = mid;
+            } else {
+                return Some(UPPER_MAP[mid].1);
+            }
+        }
+        None
+    }
+
+    /// Convert character to uppercase.
+    pub fn char_to_upper(c: char) -> char {
+        let cp = c as u32;
+        match lookup_upper(cp) {
+            Some(upper) => char::from_u32(upper).unwrap_or(c),
+            None => c,
+        }
+    }
+
+    /// Convert string to uppercase.
+    pub fn to_upper(s: &str) -> String {
+        s.chars().map(char_to_upper).collect()
+    }
+
+    /// Convert character to lowercase.
+    pub fn char_to_lower(c: char) -> char {
+        let cp = c as u32;
+        // Reverse lookup: find entry where uppercase == cp
+        for &(lower, upper) in UPPER_MAP {
+            if upper == cp {
+                return char::from_u32(lower).unwrap_or(c);
+            }
+        }
+        c
+    }
+
+    /// Convert string to lowercase.
+    pub fn to_lower(s: &str) -> String {
+        s.chars().map(char_to_lower).collect()
+    }
+
+    /// Check if character is whitespace.
+    pub fn is_whitespace(c: char) -> bool {
+        let cp = c as u32;
+        // Binary search
+        let mut lo = 0;
+        let mut hi = WHITESPACE.len();
+        while lo < hi {
+            let mid = (lo + hi) / 2;
+            if WHITESPACE[mid] < cp {
+                lo = mid + 1;
+            } else if WHITESPACE[mid] > cp {
+                hi = mid;
+            } else {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Count Unicode characters (not bytes).
+    pub fn char_count(s: &str) -> usize {
+        s.chars().count()
+    }
+
+    /// Get character at index.
+    pub fn char_at(s: &str, idx: usize) -> Option<char> {
+        s.chars().nth(idx)
+    }
+}
+
+#[cfg(feature = "embedded")]
+pub use embedded::*;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// HOST DELEGATION (Leg 2)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "host")]
+mod host {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    // Imports from JS host
+    extern "C" {
+        /// Convert string to uppercase via host.
+        /// Input: (ptr, len) of UTF-8 string
+        /// Output: writes result to out_ptr, returns length
+        fn _host_to_upper(ptr: *const u8, len: usize, out_ptr: *mut u8, out_cap: usize) -> usize;
+
+        /// Convert string to lowercase via host.
+        fn _host_to_lower(ptr: *const u8, len: usize, out_ptr: *mut u8, out_cap: usize) -> usize;
+
+        /// Check if character is whitespace via host.
+        fn _host_is_whitespace(cp: u32) -> i32;
+
+        /// Count grapheme clusters via host (for emoji etc).
+        fn _host_char_count(ptr: *const u8, len: usize) -> usize;
+    }
+
+    /// Convert string to uppercase via host.
+    pub fn to_upper(s: &str) -> String {
+        // Allocate buffer for result (UTF-8 can expand 4x worst case)
+        let mut buf = Vec::with_capacity(s.len() * 4);
+        buf.resize(s.len() * 4, 0u8);
+
+        let len = unsafe {
+            _host_to_upper(s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.capacity())
+        };
+
+        buf.truncate(len);
+        String::from_utf8(buf).unwrap_or_else(|_| String::from(s))
+    }
+
+    /// Convert string to lowercase via host.
+    pub fn to_lower(s: &str) -> String {
+        let mut buf = Vec::with_capacity(s.len() * 4);
+        buf.resize(s.len() * 4, 0u8);
+
+        let len = unsafe {
+            _host_to_lower(s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.capacity())
+        };
+
+        buf.truncate(len);
+        String::from_utf8(buf).unwrap_or_else(|_| String::from(s))
+    }
+
+    /// Check if character is whitespace via host.
+    pub fn is_whitespace(c: char) -> bool {
+        unsafe { _host_is_whitespace(c as u32) != 0 }
+    }
+
+    /// Count Unicode characters (delegates to host for grapheme accuracy).
+    pub fn char_count(s: &str) -> usize {
+        unsafe { _host_char_count(s.as_ptr(), s.len()) }
+    }
+
+    /// Character to uppercase.
+    pub fn char_to_upper(c: char) -> char {
+        let s: String = core::iter::once(c).collect();
+        to_upper(&s).chars().next().unwrap_or(c)
+    }
+
+    /// Character to lowercase.
+    pub fn char_to_lower(c: char) -> char {
+        let s: String = core::iter::once(c).collect();
+        to_lower(&s).chars().next().unwrap_or(c)
+    }
+
+    /// Get character at index.
+    pub fn char_at(s: &str, idx: usize) -> Option<char> {
+        s.chars().nth(idx)
+    }
+}
+
+#[cfg(feature = "host")]
+pub use host::*;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ASCII-ONLY FALLBACK (Legs 3 & 4)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "ascii")]
+mod ascii {
+    use alloc::string::String;
+
+    /// Convert character to uppercase (ASCII only).
+    #[inline]
+    pub fn char_to_upper(c: char) -> char {
+        if c >= 'a' && c <= 'z' {
+            ((c as u8) - 32) as char
+        } else {
+            c
+        }
+    }
+
+    /// Convert string to uppercase (ASCII only).
+    pub fn to_upper(s: &str) -> String {
+        s.chars().map(char_to_upper).collect()
+    }
+
+    /// Convert character to lowercase (ASCII only).
+    #[inline]
+    pub fn char_to_lower(c: char) -> char {
+        if c >= 'A' && c <= 'Z' {
+            ((c as u8) + 32) as char
+        } else {
+            c
+        }
+    }
+
+    /// Convert string to lowercase (ASCII only).
+    pub fn to_lower(s: &str) -> String {
+        s.chars().map(char_to_lower).collect()
+    }
+
+    /// Check if character is whitespace (ASCII only).
+    #[inline]
+    pub fn is_whitespace(c: char) -> bool {
+        matches!(c, ' ' | '\t' | '\n' | '\r' | '\x0B' | '\x0C')
+    }
+
+    /// Count characters (just iterates chars - no grapheme awareness).
+    pub fn char_count(s: &str) -> usize {
+        s.chars().count()
+    }
+
+    /// Get character at index.
+    pub fn char_at(s: &str, idx: usize) -> Option<char> {
+        s.chars().nth(idx)
+    }
+}
+
+#[cfg(feature = "ascii")]
+pub use ascii::*;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// WASM EXPORTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Shared memory for string I/O.
+static mut BUFFER: [u8; 4096] = [0; 4096];
+
+/// Write a string to the shared buffer, returning length.
+fn write_to_buffer(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let len = bytes.len().min(unsafe { BUFFER.len() });
+    unsafe {
+        BUFFER[..len].copy_from_slice(&bytes[..len]);
+    }
+    len
+}
+
+/// Read a string from the shared buffer.
+fn read_from_buffer(len: usize) -> &'static str {
+    unsafe {
+        let slice = &BUFFER[..len.min(BUFFER.len())];
+        core::str::from_utf8_unchecked(slice)
+    }
+}
+
+/// Get pointer to shared buffer.
+#[unsafe(no_mangle)]
+pub extern "C" fn get_buffer_ptr() -> *mut u8 {
+    unsafe { BUFFER.as_mut_ptr() }
+}
+
+/// Convert string in buffer to uppercase, return new length.
+#[unsafe(no_mangle)]
+pub extern "C" fn wasm_to_upper(len: usize) -> usize {
+    let s = read_from_buffer(len);
+    let result = to_upper(s);
+    write_to_buffer(&result)
+}
+
+/// Convert string in buffer to lowercase, return new length.
+#[unsafe(no_mangle)]
+pub extern "C" fn wasm_to_lower(len: usize) -> usize {
+    let s = read_from_buffer(len);
+    let result = to_lower(s);
+    write_to_buffer(&result)
+}
+
+/// Check if code point is whitespace.
+#[unsafe(no_mangle)]
+pub extern "C" fn wasm_is_whitespace(cp: u32) -> i32 {
+    match char::from_u32(cp) {
+        Some(c) => if is_whitespace(c) { 1 } else { 0 },
+        None => 0,
+    }
+}
+
+/// Count characters in string in buffer.
+#[unsafe(no_mangle)]
+pub extern "C" fn wasm_char_count(len: usize) -> usize {
+    let s = read_from_buffer(len);
+    char_count(s)
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// PANIC HANDLER
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[cfg(not(test))]
+mod alloc_impl {
+    use core::alloc::{GlobalAlloc, Layout};
+
+    struct BumpAllocator;
+
+    static mut HEAP: [u8; 32768] = [0; 32768];
+    static mut HEAP_PTR: usize = 0;
+
+    unsafe impl GlobalAlloc for BumpAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let align = layout.align();
+            let size = layout.size();
+            let ptr = HEAP_PTR;
+            let aligned = (ptr + align - 1) & !(align - 1);
+            let new_ptr = aligned + size;
+            if new_ptr > HEAP.len() {
+                core::ptr::null_mut()
+            } else {
+                HEAP_PTR = new_ptr;
+                HEAP.as_mut_ptr().add(aligned)
+            }
+        }
+
+        unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: BumpAllocator = BumpAllocator;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// TESTS
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_upper_ascii() {
+        assert_eq!(to_upper("hello"), "HELLO");
+    }
+
+    #[test]
+    fn test_to_lower_ascii() {
+        assert_eq!(to_lower("HELLO"), "hello");
+    }
+
+    #[test]
+    fn test_is_whitespace_space() {
+        assert!(is_whitespace(' '));
+        assert!(is_whitespace('\t'));
+        assert!(is_whitespace('\n'));
+        assert!(!is_whitespace('a'));
+    }
+
+    #[test]
+    fn test_char_count() {
+        assert_eq!(char_count("hello"), 5);
+    }
+
+    #[cfg(feature = "embedded")]
+    #[test]
+    fn test_to_upper_unicode() {
+        assert_eq!(to_upper("café"), "CAFÉ");
+        assert_eq!(to_upper("naïve"), "NAÏVE");
+    }
+
+    #[cfg(feature = "embedded")]
+    #[test]
+    fn test_to_upper_greek() {
+        assert_eq!(to_upper("αβγ"), "ΑΒΓ");
+    }
+
+    #[cfg(feature = "embedded")]
+    #[test]
+    fn test_unicode_whitespace() {
+        assert!(is_whitespace('\u{00A0}')); // Non-breaking space
+        assert!(is_whitespace('\u{3000}')); // Ideographic space
+    }
+}


### PR DESCRIPTION
## Summary

Two new experiments exploring WASM binary size trade-offs:

### Experiment 012 — Stdlib Size Matrix
- Small Mastermind app (translated from MVL) calling into a larger stdlib
- Compares optimization strategies: baseline, LTO, wasm-opt -Oz, LTO+wasm-opt, feature flags
- Measures dead code elimination effectiveness

### Experiment 013 — Unicode Strategies (2×2 matrix)
| | **Embedded tables** | **Host delegation (JS)** |
|---|---|---|
| **With Unicode** | Leg 1: portable, large | Leg 2: small, browser-only |
| **ASCII-only** | Leg 3: tiny, limited | Leg 4: baseline |

- Includes JS bridge for host delegation + browser test harness
- Tests: to_upper, to_lower, is_whitespace, char_count across Latin/Greek/Cyrillic

## Test plan
- [ ] Run `./build.sh` in each experiment directory
- [ ] Run `./benchmark.sh` to verify size measurements
- [ ] For 013: test browser harness with `cd host && python3 -m http.server 8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)